### PR TITLE
CI: add GitHub Actions for Android build

### DIFF
--- a/.github/workflows/build_and_deplou.yml
+++ b/.github/workflows/build_and_deplou.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JAVA_VERSION: 21.0.6
-      FLUTTER_VERSION: 3.35.2
+      FLUTTER_VERSION: 3.38.9
       APK_PATH: build/app/outputs/flutter-apk/app-release.apk
       FIREBASE_OPTIONS_PATH: lib/firebase_options.dart
       GOOGLE_SERVICES_ANDROID_PATH: android/app/google-services.json


### PR DESCRIPTION
Part of #3 

## Description

This PR adds GitHub Actions workflows to automate build verification for Android

### Android
- Builds Flutter Android **release APK**
- Runs `flutter pub get` and tests
- Uploads the APK as a GitHub Actions artifact


## Notes

- This setup is intended for **GitHub only usage**
- This is a manual trigger CI/CD, So every new PR don't start the workflow 
- No Play Store deployment is included

## Checklist

- [x] Android build workflow added
- [ ] iOS CI build workflow added
