### PR TITLE
Fix #22: Add comprehensive Firestore and Storage security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,81 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+    
+    function isOwner(userId) {
+      return isAuthenticated() && request.auth.uid == userId;
+    }
+    
+    function isValidTaskStatus(status) {
+      return status in ['OPEN', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED'];
+    }
+    
+    match /tasks/{taskId} {
+      allow read: if resource.data.status == 'OPEN' || isAuthenticated();
+      
+      allow create: if isAuthenticated() 
+        && request.resource.data.requesterId == request.auth.uid
+        && request.resource.data.status == 'OPEN'
+        && isValidTaskStatus(request.resource.data.status)
+        && request.resource.data.keys().hasAll(['requesterId', 'title', 'pickup', 'drop', 'price', 'status', 'createdAt', 'campusId', 'campusName', 'transportMode']);
+      
+      allow update: if isAuthenticated() && (
+        (resource.data.status == 'OPEN' 
+          && request.resource.data.status == 'IN_PROGRESS'
+          && request.resource.data.runnerId == request.auth.uid
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'runnerId']))
+        ||
+        (resource.data.status == 'IN_PROGRESS'
+          && request.resource.data.status == 'COMPLETED'
+          && resource.data.runnerId == request.auth.uid
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status']))
+        ||
+        (resource.data.requesterId == request.auth.uid
+          && request.resource.data.status == 'CANCELLED'
+          && resource.data.status in ['OPEN', 'IN_PROGRESS']
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status']))
+      );
+      
+      allow delete: if isAuthenticated() 
+        && resource.data.requesterId == request.auth.uid
+        && resource.data.status == 'OPEN';
+    }
+    
+    match /users/{userId} {
+      allow read: if isAuthenticated();
+      
+      allow create: if isAuthenticated() 
+        && request.auth.uid == userId;
+      
+      allow update: if isAuthenticated() 
+        && request.auth.uid == userId;
+      
+      allow delete: if isAuthenticated() 
+        && request.auth.uid == userId;
+    }
+    
+    match /shops/{shopId} {
+      allow read: if true;
+      
+      allow create: if isAuthenticated()
+        && request.resource.data.createdBy == request.auth.uid
+        && request.resource.data.keys().hasAll(['campusId', 'campusName', 'name', 'category', 'contactPhone', 'location', 'createdBy', 'createdAt']);
+      
+      allow update: if isAuthenticated() 
+        && resource.data.createdBy == request.auth.uid;
+      
+      allow delete: if isAuthenticated() 
+        && resource.data.createdBy == request.auth.uid;
+    }
+    
+    match /campuses/{campusId} {
+      allow read: if true;
+      allow write: if false;
+    }
+  }
+}

--- a/lib/data/models/task_model.dart
+++ b/lib/data/models/task_model.dart
@@ -3,22 +3,22 @@
 class TaskModel {
   final String id;
   final String requesterId;
+  final String? runnerId;
   final String title;
   final String pickup;
   final String drop;
   final String price;
-  final String status; // 'OPEN', 'ACCEPTED', 'COMPLETED'
+  final String status;
   final DateTime createdAt;
   final String campusId;
   final String campusName;
   final String transportMode;
-
-  // --- NEW FIELD ADDED ---
-  final String? fileUrl; // URL where the PDF is stored in Firebase Storage
+  final String? fileUrl;
 
   TaskModel({
     required this.id,
     required this.requesterId,
+    this.runnerId,
     required this.title,
     required this.pickup,
     required this.drop,
@@ -28,15 +28,14 @@ class TaskModel {
     required this.campusId,
     required this.campusName,
     required this.transportMode,
-    // --- NEW FIELD IN CONSTRUCTOR ---
     this.fileUrl,
   });
 
-  // Convert Firebase Data -> Dart Object
   factory TaskModel.fromMap(Map<String, dynamic> map, String docId) {
     return TaskModel(
       id: docId,
       requesterId: map['requesterId'] ?? '',
+      runnerId: map['runnerId'],
       title: map['title'] ?? '',
       pickup: map['pickup'] ?? '',
       drop: map['drop'] ?? '',
@@ -46,15 +45,14 @@ class TaskModel {
       campusId: map['campusId'] ?? 'unknown',
       campusName: map['campusName'] ?? 'Unknown Campus',
       transportMode: map['transportMode'] ?? 'Walking',
-      // --- FROM MAP: Reads the URL from Firestore ---
       fileUrl: map['fileUrl'],
     );
   }
 
-  // Convert Dart Object -> Firebase Data
   Map<String, dynamic> toMap() {
     return {
       'requesterId': requesterId,
+      if (runnerId != null) 'runnerId': runnerId,
       'title': title,
       'pickup': pickup,
       'drop': drop,
@@ -64,7 +62,6 @@ class TaskModel {
       'campusId': campusId,
       'campusName': campusName,
       'transportMode': transportMode,
-      // --- TO MAP: Writes the URL to Firestore ---
       'fileUrl': fileUrl,
     };
   }

--- a/lib/data/repositories/task_repository.dart
+++ b/lib/data/repositories/task_repository.dart
@@ -102,8 +102,7 @@ class TaskRepository {
     });
   }
 
-  // 3. UPDATE (Accept or Complete Task) - NEW CODE
-  Future<void> updateTaskStatus(String taskId, String newStatus) async {
+  Future<void> updateTaskStatus(String taskId, String newStatus, {String? runnerId}) async {
     if (!AppMode.backendEnabled) {
       final index = _demoTasks.indexWhere((task) => task.id == taskId);
       if (index == -1) return;
@@ -111,6 +110,7 @@ class TaskRepository {
       _demoTasks[index] = TaskModel(
         id: old.id,
         requesterId: old.requesterId,
+        runnerId: runnerId ?? old.runnerId,
         title: old.title,
         pickup: old.pickup,
         drop: old.drop,
@@ -128,9 +128,11 @@ class TaskRepository {
 
     try {
       final firestore = FirebaseFirestore.instance;
-      await firestore.collection('tasks').doc(taskId).update({
-        'status': newStatus,
-      });
+      final updateData = <String, dynamic>{'status': newStatus};
+      if (runnerId != null) {
+        updateData['runnerId'] = runnerId;
+      }
+      await firestore.collection('tasks').doc(taskId).update(updateData);
     } catch (e) {
       throw Exception('Failed to update task: $e');
     }

--- a/lib/presentation/screens/home/runner_home_screen.dart
+++ b/lib/presentation/screens/home/runner_home_screen.dart
@@ -297,13 +297,18 @@ class _RunnerHomeScreenState extends ConsumerState<RunnerHomeScreen> {
                                         return;
                                       }
 
-                                      // Call the Repository to update status to IN_PROGRESS
                                       try {
+                                        final currentUser = ref.read(authRepositoryProvider).getCurrentUser();
+                                        if (currentUser == null) {
+                                          throw Exception('User not authenticated');
+                                        }
+                                        
                                         await ref
                                             .read(taskRepositoryProvider)
                                             .updateTaskStatus(
                                               task.id,
                                               'IN_PROGRESS',
+                                              runnerId: currentUser.uid,
                                             );
 
                                         if (context.mounted) {

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,47 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+    
+    function isOwner(userId) {
+      return isAuthenticated() && request.auth.uid == userId;
+    }
+    
+    function isValidFileSize() {
+      return request.resource.size < 10 * 1024 * 1024;
+    }
+    
+    function isValidFileType() {
+      return request.resource.contentType.matches('application/pdf')
+        || request.resource.contentType.matches('image/.*');
+    }
+    
+    match /tasks/{userId}/{fileName} {
+      allow write: if isOwner(userId)
+        && isValidFileSize()
+        && isValidFileType();
+      
+      allow read: if isAuthenticated();
+    }
+    
+    match /shops/{shopId}/{fileName} {
+      allow write: if isAuthenticated()
+        && isValidFileSize()
+        && isValidFileType();
+      
+      allow read: if true;
+    }
+    
+    match /users/{userId}/{fileName} {
+      allow write: if isOwner(userId)
+        && isValidFileSize()
+        && isValidFileType();
+      
+      allow read: if isAuthenticated();
+    }
+  }
+}


### PR DESCRIPTION
## Fix #22: Add Firestore and Storage Security Rules

### Problem
The application had NO security rules, allowing anyone to read/write/delete any data, leading to critical vulnerabilities.

### Solution
- ✅ Added `firestore.rules` with authentication and authorization
- ✅ Added `storage.rules` with file access controls
- ✅ Added `runnerId` field to track task acceptance
- ✅ Implemented strict task status flow (OPEN → IN_PROGRESS → COMPLETED)

### Security Improvements
- Only authenticated users can create/modify data
- Only assigned runners can complete tasks
- Only requesters can cancel their own tasks
- File uploads limited to 10MB, PDF/images only
- Users can only modify their own data

### Changes
- `firestore.rules` - Firestore security rules
- `storage.rules` - Storage security rules
- `lib/data/models/task_model.dart` - Added runnerId field
- `lib/data/repositories/task_repository.dart` - Updated status logic
- `lib/presentation/screens/home/runner_home_screen.dart` - Pass runnerId on accept

### Testing
- [x] All code passes diagnostics
- [x] No breaking changes to existing functionality

### Deployment
Deploy rules with: `firebase deploy --only firestore:rules,storage:rules`

Closes #22
