### PR TITLE
Implement task filtering and sorting in task lists #60

### DIFF
--- a/lib/presentation/screens/home/runner_home_screen.dart
+++ b/lib/presentation/screens/home/runner_home_screen.dart
@@ -114,7 +114,6 @@ class _RunnerHomeScreenState extends ConsumerState<RunnerHomeScreen> {
           },
           icon: const Icon(Icons.leaderboard),
         ),
-          IconButton(onPressed: () {}, icon: Icon(PhosphorIcons.funnel())),
           IconButton(onPressed: () {}, icon: Icon(PhosphorIcons.bell())),
           IconButton(
             onPressed: () {
@@ -230,24 +229,23 @@ class _RunnerHomeScreenState extends ConsumerState<RunnerHomeScreen> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              mainAxisAlignment: MainAxisAlignment.end,
               children: [
-                ElevatedButton.icon(
-                  onPressed: () {},
-                  icon: const Icon(Icons.filter_list),
-                  label: const Text("Filter"),
+                const Text('Sort by: '),
+                DropdownButton<String>(
+                  value: sortType,
+                  items: const [
+                    DropdownMenuItem(value: 'latest', child: Text('Latest created')),
+                    DropdownMenuItem(value: 'highest_price', child: Text('Highest price')),
+                  ],
+                  onChanged: (value) {
+                    if (value != null) {
+                      setState(() {
+                        sortType = value;
+                      });
+                    }
+                  },
                 ),
-                ElevatedButton.icon(
-                onPressed: () {
-                  setState(() {
-                    sortType = sortType == "highest_price"
-                        ? "latest"
-                        : "highest_price";
-                  });
-                },
-                icon: const Icon(Icons.sort),
-                label: const Text("Sort"),
-              ),
               ],
             ),
           ),

--- a/lib/presentation/screens/tracking/my_tasks_screen.dart
+++ b/lib/presentation/screens/tracking/my_tasks_screen.dart
@@ -7,11 +7,27 @@ import '../../../logic/auth_provider.dart';
 import '../../../core/utils/formatters.dart';
 import 'live_tracking_screen.dart';
 
-class MyTasksScreen extends ConsumerWidget {
+class MyTasksScreen extends ConsumerStatefulWidget {
   const MyTasksScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<MyTasksScreen> createState() => _MyTasksScreenState();
+}
+
+class _MyTasksScreenState extends ConsumerState<MyTasksScreen> {
+  String _selectedStatus = 'All';
+  String _sortOption = 'Latest';
+
+  final List<String> _statusOptions = [
+    'All',
+    'Open',
+    'In Progress',
+    'Completed',
+    'Cancelled'
+  ];
+
+  @override
+  Widget build(BuildContext context) {
     final currentUser = ref.watch(authRepositoryProvider).getCurrentUser();
 
     if (currentUser == null) {
@@ -27,54 +43,134 @@ class MyTasksScreen extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('My Tasks'),
       ),
-      body: StreamBuilder<QuerySnapshot>(
-        stream: FirebaseFirestore.instance
-            .collection('tasks')
-            .where('requesterId', isEqualTo: currentUser.uid)
-            .orderBy('createdAt', descending: true)
-            .snapshots(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-
-          if (snapshot.hasError) {
-            return Center(child: Text('Error: ${snapshot.error}'));
-          }
-
-          if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-            return Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    PhosphorIcons.package(),
-                    size: 64,
-                    color: Colors.grey,
+      body: Column(
+        children: [
+          // Filter Chips
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: _statusOptions.map((status) {
+                return Padding(
+                  padding: const EdgeInsets.only(right: 8.0),
+                  child: ChoiceChip(
+                    label: Text(status),
+                    selected: _selectedStatus == status,
+                    onSelected: (selected) {
+                      if (selected) {
+                        setState(() {
+                          _selectedStatus = status;
+                        });
+                      }
+                    },
                   ),
-                  const SizedBox(height: 16),
-                  const Text('No tasks yet'),
-                ],
-              ),
-            );
-          }
+                );
+              }).toList(),
+            ),
+          ),
+          
+          // Sort Dropdown
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                const Text('Sort by: '),
+                DropdownButton<String>(
+                  value: _sortOption,
+                  items: const [
+                    DropdownMenuItem(value: 'Latest', child: Text('Latest created')),
+                    DropdownMenuItem(value: 'Highest Price', child: Text('Highest price')),
+                  ],
+                  onChanged: (value) {
+                    if (value != null) {
+                      setState(() {
+                        _sortOption = value;
+                      });
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+          
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: FirebaseFirestore.instance
+                  .collection('tasks')
+                  .where('requesterId', isEqualTo: currentUser.uid)
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
 
-          final tasks = snapshot.data!.docs
-              .map((doc) => TaskModel.fromMap(
-                    doc.data() as Map<String, dynamic>,
-                    doc.id,
-                  ))
-              .toList();
+                if (snapshot.hasError) {
+                  return Center(child: Text('Error: ${snapshot.error}'));
+                }
 
-          return ListView.builder(
-            padding: const EdgeInsets.all(16),
-            itemCount: tasks.length,
-            itemBuilder: (context, index) {
-              final task = tasks[index];
-              return _TaskItem(task: task);
-            },
-          );
-        },
+                if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                  return _buildEmptyState();
+                }
+
+                var tasks = snapshot.data!.docs
+                    .map((doc) => TaskModel.fromMap(
+                          doc.data() as Map<String, dynamic>,
+                          doc.id,
+                        ))
+                    .toList();
+
+                // 1. FILTER
+                if (_selectedStatus != 'All') {
+                  final mappedStatus = _selectedStatus.toUpperCase().replaceAll(' ', '_');
+                  tasks = tasks.where((task) => task.status == mappedStatus).toList();
+                }
+
+                if (tasks.isEmpty) {
+                  return _buildEmptyState();
+                }
+
+                // 2. SORT
+                if (_sortOption == 'Latest') {
+                  tasks.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+                } else if (_sortOption == 'Highest Price') {
+                  // Ensure we parse price correctly even if it's string-based
+                   tasks.sort((a, b) {
+                     final priceA = double.tryParse(a.price) ?? 0.0;
+                     final priceB = double.tryParse(b.price) ?? 0.0;
+                     return priceB.compareTo(priceA);
+                   });
+                }
+
+                return ListView.builder(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: tasks.length,
+                  itemBuilder: (context, index) {
+                    final task = tasks[index];
+                    return _TaskItem(task: task);
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+     return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            PhosphorIcons.package(),
+            size: 64,
+            color: Colors.grey,
+          ),
+          const SizedBox(height: 16),
+          const Text('No tasks found'),
+        ],
       ),
     );
   }


### PR DESCRIPTION
# Task Filtering & Sorting Implementation
Fixes #60
## Description
Currently, tasks on the `MyTasksScreen` are displayed in a simple list without any filtering or sorting options. 
This Pull Request introduces status filtering and sorting functionality to improve usability for both Runners and Requesters.


## Changes Proposed:
### MyTasksScreen (Requester View)
- Converted `MyTasksScreen` to a `ConsumerStatefulWidget` to handle local filtering state.
- Added horizontally-scrollable `ChoiceChip`s to filter tasks by status (`All`, `Open`, `In Progress`, `Completed`, `Cancelled`).
- Added a `DropdownButton` to sort tasks by:
  - **Latest created** (default)
  - **Highest price**
- Implemented an empty-state UI when a selected filter yields zero tasks.

### RunnerHomeScreen (Runner View)
- Refined the task sorting UI by replacing the confusing toggle icon with a clear `DropdownButton` (Latest vs Highest Price).
- Removed the dummy filter button as `RunnerHomeScreen` only queries tasks with an `OPEN` status naturally.
