### PR TITLE
Task Filtering + Pagination

### DIFF
--- a/backend/src/controllers/task.controller.js
+++ b/backend/src/controllers/task.controller.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose";
 
-import { Task } from "../models/task.model.js";
+import { allowedTaskStatuses, allowedTransportModes, Task } from "../models/task.model.js";
 import { ApiError } from "../utils/ApiError.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
@@ -46,6 +46,8 @@ const sanitizeTask = (task) => ({
   description: task.description,
   pickupLocation: task.pickupLocation,
   dropoffLocation: task.dropoffLocation,
+  campus: task.campus,
+  transportMode: task.transportMode,
   reward: task.reward,
   status: task.status,
   requestedBy: sanitizeTaskUser(task.requestedBy),
@@ -63,6 +65,187 @@ const ensureValidTaskId = (taskId) => {
   if (!mongoose.isValidObjectId(taskId)) {
     throw new ApiError(400, "Invalid task id provided");
   }
+};
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const encodeCursor = (task) => {
+  return Buffer.from(
+    JSON.stringify({
+      createdAt: task.createdAt.toISOString(),
+      id: String(task._id),
+    }),
+  ).toString("base64url");
+};
+
+const decodeCursor = (cursor) => {
+  try {
+    const decoded = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+
+    if (!decoded?.createdAt || !decoded?.id) {
+      throw new Error("Cursor payload missing fields");
+    }
+
+    ensureValidTaskId(decoded.id);
+
+    const createdAt = new Date(decoded.createdAt);
+    if (Number.isNaN(createdAt.getTime())) {
+      throw new Error("Cursor date invalid");
+    }
+
+    return {
+      createdAt,
+      id: decoded.id,
+    };
+  } catch {
+    throw new ApiError(400, "Invalid cursor provided");
+  }
+};
+
+const resolveTaskFeedQuery = (query, overrides = {}) => {
+  const {
+    status,
+    campus,
+    transportMode,
+    search,
+    requestedBy,
+    assignedRunner,
+    page = 1,
+    limit = 20,
+    sort = "desc",
+    cursor,
+  } = query;
+
+  const filters = {};
+
+  const resolvedStatus = overrides.status || status;
+  if (resolvedStatus) {
+    if (!allowedTaskStatuses.includes(resolvedStatus)) {
+      throw new ApiError(400, "Invalid task status filter");
+    }
+
+    filters.status = resolvedStatus;
+  }
+
+  const resolvedCampus = overrides.campus || campus;
+  if (resolvedCampus) {
+    filters.campus = resolvedCampus.trim();
+  }
+
+  const resolvedTransportMode = overrides.transportMode || transportMode;
+  if (resolvedTransportMode) {
+    if (!allowedTransportModes.includes(resolvedTransportMode)) {
+      throw new ApiError(400, "Invalid transport mode filter");
+    }
+
+    filters.transportMode = resolvedTransportMode;
+  }
+
+  if (requestedBy) {
+    ensureValidTaskId(requestedBy);
+    filters.requestedBy = requestedBy;
+  }
+
+  if (assignedRunner) {
+    ensureValidTaskId(assignedRunner);
+    filters.assignedRunner = assignedRunner;
+  }
+
+  if (search?.trim()) {
+    const pattern = new RegExp(escapeRegex(search.trim()), "i");
+    filters.$or = [
+      { title: pattern },
+      { description: pattern },
+      { pickupLocation: pattern },
+      { dropoffLocation: pattern },
+      { campus: pattern },
+    ];
+  }
+
+  const resolvedSort = String(sort).toLowerCase() === "asc" ? 1 : -1;
+  const resolvedPage = Math.max(Number(page) || 1, 1);
+  const resolvedLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
+  const decodedCursor = cursor ? decodeCursor(cursor) : null;
+
+  if (decodedCursor) {
+    filters.$or = [
+      {
+        createdAt: resolvedSort === -1 ? { $lt: decodedCursor.createdAt } : { $gt: decodedCursor.createdAt },
+      },
+      {
+        createdAt: decodedCursor.createdAt,
+        _id: resolvedSort === -1 ? { $lt: decodedCursor.id } : { $gt: decodedCursor.id },
+      },
+    ];
+
+    if (search?.trim()) {
+      const pattern = new RegExp(escapeRegex(search.trim()), "i");
+      filters.$and = [
+        {
+          $or: [
+            { title: pattern },
+            { description: pattern },
+            { pickupLocation: pattern },
+            { dropoffLocation: pattern },
+            { campus: pattern },
+          ],
+        },
+        { $or: filters.$or },
+      ];
+      delete filters.$or;
+    }
+  }
+
+  return {
+    filters,
+    resolvedSort,
+    resolvedPage,
+    resolvedLimit,
+    usesCursor: Boolean(decodedCursor),
+  };
+};
+
+const fetchTaskFeed = async (query, overrides = {}) => {
+  const { filters, resolvedSort, resolvedPage, resolvedLimit, usesCursor } =
+    resolveTaskFeedQuery(query, overrides);
+
+  const sortOrder = { createdAt: resolvedSort, _id: resolvedSort };
+  const baseQuery = Task.find(filters).populate(populateTaskFields).sort(sortOrder);
+
+  if (usesCursor) {
+    const tasks = await baseQuery.limit(resolvedLimit + 1);
+    const hasMore = tasks.length > resolvedLimit;
+    const items = hasMore ? tasks.slice(0, resolvedLimit) : tasks;
+
+    return {
+      items,
+      pagination: {
+        mode: "cursor",
+        limit: resolvedLimit,
+        nextCursor: hasMore ? encodeCursor(items[items.length - 1]) : null,
+        hasMore,
+        sort: resolvedSort === 1 ? "asc" : "desc",
+      },
+    };
+  }
+
+  const [tasks, total] = await Promise.all([
+    baseQuery.skip((resolvedPage - 1) * resolvedLimit).limit(resolvedLimit),
+    Task.countDocuments(filters),
+  ]);
+
+  return {
+    items: tasks,
+    pagination: {
+      mode: "page",
+      page: resolvedPage,
+      limit: resolvedLimit,
+      total,
+      totalPages: Math.ceil(total / resolvedLimit) || 1,
+      hasMore: resolvedPage * resolvedLimit < total,
+      sort: resolvedSort === 1 ? "asc" : "desc",
+    },
+  };
 };
 
 const assertTransitionAllowed = (task, nextStatus) => {
@@ -109,7 +292,7 @@ const ensureTaskRequesterOrAdmin = (task, user) => {
 };
 
 const createTask = asyncHandler(async (req, res) => {
-  const { title, description, pickupLocation, dropoffLocation, reward } = req.body;
+  const { title, description, pickupLocation, dropoffLocation, campus, transportMode, reward } = req.body;
 
   if (!title || !description || !pickupLocation || !dropoffLocation) {
     throw new ApiError(
@@ -123,11 +306,17 @@ const createTask = asyncHandler(async (req, res) => {
     throw new ApiError(400, "reward must be a non-negative number");
   }
 
+  if (transportMode && !allowedTransportModes.includes(transportMode)) {
+    throw new ApiError(400, "Invalid transport mode provided");
+  }
+
   const task = await Task.create({
     title: title.trim(),
     description: description.trim(),
     pickupLocation: pickupLocation.trim(),
     dropoffLocation: dropoffLocation.trim(),
+    campus: campus?.trim() || "",
+    transportMode: transportMode || "other",
     reward: normalizedReward,
     requestedBy: req.user._id,
   });
@@ -139,14 +328,48 @@ const createTask = asyncHandler(async (req, res) => {
     .json(new ApiResponse(201, sanitizeTask(createdTask), "Task created successfully"));
 });
 
-const listOpenTasks = asyncHandler(async (_, res) => {
-  const tasks = await Task.find({ status: "open" })
-    .populate(populateTaskFields)
-    .sort({ createdAt: -1 });
+const listOpenTasks = asyncHandler(async (req, res) => {
+  const { items, pagination } = await fetchTaskFeed(req.query, { status: "open" });
 
   res
     .status(200)
-    .json(new ApiResponse(200, tasks.map(sanitizeTask), "Open tasks fetched successfully"));
+    .json(
+      new ApiResponse(
+        200,
+        {
+          items: items.map(sanitizeTask),
+          pagination,
+          filters: {
+            search: req.query.search || "",
+            campus: req.query.campus || "",
+            status: "open",
+            transportMode: req.query.transportMode || "",
+          },
+        },
+        "Open tasks fetched successfully",
+      ),
+    );
+});
+
+const listTasks = asyncHandler(async (req, res) => {
+  const { items, pagination } = await fetchTaskFeed(req.query);
+
+  res.status(200).json(
+    new ApiResponse(
+      200,
+      {
+        items: items.map(sanitizeTask),
+        pagination,
+        filters: {
+          search: req.query.search || "",
+          campus: req.query.campus || "",
+          status: req.query.status || "",
+          transportMode: req.query.transportMode || "",
+        },
+      },
+      "Tasks fetched successfully",
+    ),
+  );
 });
 
 const getTaskById = asyncHandler(async (req, res) => {
@@ -269,6 +492,7 @@ export {
   completeTask,
   createTask,
   getTaskById,
+  listTasks,
   listOpenTasks,
   listProtectedTaskActions,
   markTaskInProgress,

--- a/backend/src/docs/swagger.js
+++ b/backend/src/docs/swagger.js
@@ -36,6 +36,12 @@ const taskSchema = {
     },
     pickupLocation: { type: "string", example: "Academic Block A" },
     dropoffLocation: { type: "string", example: "Hostel 3 Reception" },
+    campus: { type: "string", example: "VIT Bhopal" },
+    transportMode: {
+      type: "string",
+      enum: ["walk", "bike", "car", "public_transport", "other"],
+      example: "bike",
+    },
     reward: { type: "number", example: 80 },
     status: {
       type: "string",
@@ -187,9 +193,49 @@ const swaggerDocument = {
           },
           pickupLocation: { type: "string", example: "Academic Block A" },
           dropoffLocation: { type: "string", example: "Hostel 3 Reception" },
+          campus: { type: "string", example: "VIT Bhopal" },
+          transportMode: {
+            type: "string",
+            enum: ["walk", "bike", "car", "public_transport", "other"],
+            example: "bike",
+          },
           reward: { type: "number", example: 80 },
         },
       },
+      TaskFeedResponse: apiResponse(
+        {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: { $ref: "#/components/schemas/Task" },
+            },
+            pagination: {
+              type: "object",
+              properties: {
+                mode: { type: "string", enum: ["page", "cursor"], example: "page" },
+                page: { type: "integer", example: 1 },
+                limit: { type: "integer", example: 20 },
+                total: { type: "integer", example: 42 },
+                totalPages: { type: "integer", example: 3 },
+                hasMore: { type: "boolean", example: true },
+                nextCursor: { type: "string", nullable: true, example: "eyJjcmVhdGVkQXQiOiIyMDI2LTAzLTA3VDE0OjAwOjAwLjAwMFoiLCJpZCI6IjY3Y2E3MmQ5OTllYTQwZjJhYmM5ODc2NSJ9" },
+                sort: { type: "string", enum: ["asc", "desc"], example: "desc" },
+              },
+            },
+            filters: {
+              type: "object",
+              properties: {
+                search: { type: "string", example: "lab" },
+                campus: { type: "string", example: "VIT Bhopal" },
+                status: { type: "string", example: "open" },
+                transportMode: { type: "string", example: "bike" },
+              },
+            },
+          },
+        },
+        "Tasks fetched successfully",
+      ),
       CancelTaskRequest: {
         type: "object",
         properties: {
@@ -205,8 +251,19 @@ const swaggerDocument = {
       ),
       TaskListResponse: apiResponse(
         {
-          type: "array",
-          items: { $ref: "#/components/schemas/Task" },
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: { $ref: "#/components/schemas/Task" },
+            },
+            pagination: {
+              type: "object",
+            },
+            filters: {
+              type: "object",
+            },
+          },
         },
         "Open tasks fetched successfully",
       ),
@@ -444,6 +501,28 @@ const swaggerDocument = {
         tags: ["Tasks"],
         summary: "List all open tasks",
         security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            in: "query",
+            name: "page",
+            schema: { type: "integer", example: 1 },
+          },
+          {
+            in: "query",
+            name: "limit",
+            schema: { type: "integer", example: 20 },
+          },
+          {
+            in: "query",
+            name: "sort",
+            schema: { type: "string", enum: ["asc", "desc"], example: "desc" },
+          },
+          {
+            in: "query",
+            name: "cursor",
+            schema: { type: "string" },
+          },
+        ],
         responses: {
           200: {
             description: "Open tasks fetched successfully",
@@ -457,6 +536,70 @@ const swaggerDocument = {
       },
     },
     "/api/v1/tasks": {
+      get: {
+        tags: ["Tasks"],
+        summary: "Search, filter, sort, and paginate tasks",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            in: "query",
+            name: "search",
+            schema: { type: "string", example: "lab" },
+          },
+          {
+            in: "query",
+            name: "campus",
+            schema: { type: "string", example: "VIT Bhopal" },
+          },
+          {
+            in: "query",
+            name: "status",
+            schema: {
+              type: "string",
+              enum: ["open", "accepted", "in_progress", "completed", "cancelled"],
+            },
+          },
+          {
+            in: "query",
+            name: "transportMode",
+            schema: {
+              type: "string",
+              enum: ["walk", "bike", "car", "public_transport", "other"],
+            },
+          },
+          {
+            in: "query",
+            name: "sort",
+            schema: { type: "string", enum: ["asc", "desc"], example: "desc" },
+          },
+          {
+            in: "query",
+            name: "page",
+            schema: { type: "integer", example: 1 },
+          },
+          {
+            in: "query",
+            name: "limit",
+            schema: { type: "integer", example: 20 },
+          },
+          {
+            in: "query",
+            name: "cursor",
+            schema: { type: "string" },
+            description: "Optional cursor token for cursor-based pagination; when provided, page is ignored.",
+          },
+        ],
+        responses: {
+          200: {
+            description: "Tasks fetched successfully",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TaskFeedResponse" },
+              },
+            },
+          },
+        },
+      },
       post: {
         tags: ["Tasks"],
         summary: "Create a new task",

--- a/backend/src/models/task.model.js
+++ b/backend/src/models/task.model.js
@@ -8,6 +8,8 @@ const allowedTaskStatuses = [
   "cancelled",
 ];
 
+const allowedTransportModes = ["walk", "bike", "car", "public_transport", "other"];
+
 const taskSchema = new mongoose.Schema(
   {
     title: {
@@ -29,6 +31,18 @@ const taskSchema = new mongoose.Schema(
       type: String,
       required: true,
       trim: true,
+    },
+    campus: {
+      type: String,
+      trim: true,
+      default: "",
+      index: true,
+    },
+    transportMode: {
+      type: String,
+      enum: allowedTransportModes,
+      default: "other",
+      index: true,
     },
     reward: {
       type: Number,
@@ -81,9 +95,11 @@ const taskSchema = new mongoose.Schema(
 );
 
 taskSchema.index({ status: 1, createdAt: -1 });
+taskSchema.index({ campus: 1, status: 1, createdAt: -1 });
+taskSchema.index({ transportMode: 1, status: 1, createdAt: -1 });
 taskSchema.index({ requestedBy: 1, createdAt: -1 });
 taskSchema.index({ assignedRunner: 1, createdAt: -1 });
 
 const Task = mongoose.model("Task", taskSchema);
 
-export { Task, allowedTaskStatuses };
+export { Task, allowedTaskStatuses, allowedTransportModes };

--- a/backend/src/routes/task.routes.js
+++ b/backend/src/routes/task.routes.js
@@ -6,6 +6,7 @@ import {
   completeTask,
   createTask,
   getTaskById,
+  listTasks,
   listOpenTasks,
   listProtectedTaskActions,
   markTaskInProgress,
@@ -17,6 +18,7 @@ const router = Router();
 router.use(verifyJWT);
 
 router.get("/protected-actions", listProtectedTaskActions);
+router.get("/", listTasks);
 router.get("/open", listOpenTasks);
 router.get("/:taskId", getTaskById);
 router.post("/", authorizeRoles("requester", "admin"), createTask);


### PR DESCRIPTION
#71 solved 

This PR enhances the backend task feed by adding search, filtering, sorting, and pagination APIs for Campus Runner without making any frontend changes. It extends the task model with campus and transport mode metadata, adds backend filtering by campus, status, and transport mode, supports text search across task fields, and enables sorting by [createdAt]in ascending or descending order. The update also introduces both page-based and cursor-based pagination for task listings, applies the same query capabilities to the open-tasks endpoint, and updates the Swagger documentation to describe the new query parameters, response structure, and task payload fields so the task feed is ready to scale on the backend side.