### PR TITLE
Task Expiry and Auto-Reopen

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "nodemon src/index.js",
     "start": "node src/index.js",
-    "test": "node --test"
+    "test": "node --test --test-concurrency=1"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/background/taskExpiry.monitor.js
+++ b/backend/src/background/taskExpiry.monitor.js
@@ -1,0 +1,129 @@
+import { Task } from "../models/task.model.js";
+
+const DEFAULT_TASK_ACCEPTANCE_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_TASK_EXPIRY_CHECK_INTERVAL_MS = 60 * 1000;
+
+const parsePositiveMilliseconds = (value, fallbackValue) => {
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    return fallbackValue;
+  }
+
+  return parsedValue;
+};
+
+const getTaskAcceptanceTimeoutMs = () => {
+  return parsePositiveMilliseconds(
+    process.env.TASK_ACCEPTANCE_TIMEOUT_MS,
+    DEFAULT_TASK_ACCEPTANCE_TIMEOUT_MS,
+  );
+};
+
+const getTaskExpiryCheckIntervalMs = () => {
+  return parsePositiveMilliseconds(
+    process.env.TASK_EXPIRY_CHECK_INTERVAL_MS,
+    DEFAULT_TASK_EXPIRY_CHECK_INTERVAL_MS,
+  );
+};
+
+const calculateAssignmentExpiryDate = (
+  acceptedAt = new Date(),
+  acceptanceTimeoutMs = getTaskAcceptanceTimeoutMs(),
+) => {
+  return new Date(acceptedAt.getTime() + acceptanceTimeoutMs);
+};
+
+const reopenExpiredAcceptedTasks = async ({
+  now = new Date(),
+  acceptanceTimeoutMs = getTaskAcceptanceTimeoutMs(),
+} = {}) => {
+  const checkedAt = now instanceof Date ? now : new Date(now);
+  const timeoutCutoff = new Date(checkedAt.getTime() - acceptanceTimeoutMs);
+  const expirationReason = `Task acceptance expired after ${acceptanceTimeoutMs}ms`;
+
+  const result = await Task.updateMany(
+    {
+      status: "accepted",
+      isArchived: false,
+      startedAt: null,
+      acceptedAt: { $ne: null },
+      $or: [
+        { assignmentExpiresAt: { $lte: checkedAt } },
+        {
+          assignmentExpiresAt: null,
+          acceptedAt: { $lte: timeoutCutoff },
+        },
+      ],
+    },
+    {
+      $set: {
+        status: "open",
+        assignedRunner: null,
+        acceptedAt: null,
+        assignmentExpiresAt: null,
+        startedAt: null,
+        completedAt: null,
+        cancelledAt: null,
+        cancellationReason: "",
+        lastExpiredAt: checkedAt,
+        reopenedAt: checkedAt,
+        expirationReason,
+      },
+      $inc: {
+        expiryReopenCount: 1,
+      },
+    },
+  );
+
+  return {
+    checkedAt,
+    acceptanceTimeoutMs,
+    reopenedCount: result.modifiedCount ?? 0,
+  };
+};
+
+const startTaskExpiryMonitor = ({
+  acceptanceTimeoutMs = getTaskAcceptanceTimeoutMs(),
+  intervalMs = getTaskExpiryCheckIntervalMs(),
+  logger = console,
+} = {}) => {
+  let isRunning = false;
+
+  const runIteration = async () => {
+    if (isRunning) {
+      return;
+    }
+
+    isRunning = true;
+
+    try {
+      const result = await reopenExpiredAcceptedTasks({ acceptanceTimeoutMs });
+
+      if (result.reopenedCount > 0) {
+        logger.log(`Auto-reopened ${result.reopenedCount} expired accepted task(s).`);
+      }
+    } catch (error) {
+      logger.error("Task expiry monitor failed", error);
+    } finally {
+      isRunning = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void runIteration();
+  }, intervalMs);
+
+  timer.unref?.();
+  void runIteration();
+
+  return () => clearInterval(timer);
+};
+
+export {
+  calculateAssignmentExpiryDate,
+  getTaskAcceptanceTimeoutMs,
+  getTaskExpiryCheckIntervalMs,
+  reopenExpiredAcceptedTasks,
+  startTaskExpiryMonitor,
+};

--- a/backend/src/controllers/task.controller.js
+++ b/backend/src/controllers/task.controller.js
@@ -1,6 +1,11 @@
 import mongoose from "mongoose";
 
-import { allowedTaskStatuses, allowedTransportModes, Task } from "../models/task.model.js";
+import { calculateAssignmentExpiryDate } from "../background/taskExpiry.monitor.js";
+import {
+  allowedTaskStatuses,
+  allowedTransportModes,
+  Task,
+} from "../models/task.model.js";
 import { ApiError } from "../utils/ApiError.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
@@ -13,14 +18,24 @@ const taskTransitionMap = {
   cancelled: [],
 };
 
+const baseTaskUserSelection = "fullName email phoneNumber role isVerified isActive";
+
 const populateTaskFields = [
   {
     path: "requestedBy",
-    select: "fullName email phoneNumber role isVerified isActive",
+    select: baseTaskUserSelection,
   },
   {
     path: "assignedRunner",
-    select: "fullName email phoneNumber role isVerified isActive",
+    select: baseTaskUserSelection,
+  },
+];
+
+const detailedTaskPopulateFields = [
+  ...populateTaskFields,
+  {
+    path: "archivedBy",
+    select: baseTaskUserSelection,
   },
 ];
 
@@ -53,10 +68,15 @@ const sanitizeTask = (task) => ({
   requestedBy: sanitizeTaskUser(task.requestedBy),
   assignedRunner: sanitizeTaskUser(task.assignedRunner),
   acceptedAt: task.acceptedAt,
+  assignmentExpiresAt: task.assignmentExpiresAt,
   startedAt: task.startedAt,
   completedAt: task.completedAt,
   cancelledAt: task.cancelledAt,
   cancellationReason: task.cancellationReason,
+  lastExpiredAt: task.lastExpiredAt,
+  reopenedAt: task.reopenedAt,
+  expiryReopenCount: task.expiryReopenCount,
+  expirationReason: task.expirationReason,
   isArchived: task.isArchived,
   archivedAt: task.archivedAt,
   archiveReason: task.archiveReason,
@@ -68,6 +88,12 @@ const sanitizeTask = (task) => ({
 const ensureValidTaskId = (taskId) => {
   if (!mongoose.isValidObjectId(taskId)) {
     throw new ApiError(400, "Invalid task id provided");
+  }
+};
+
+const ensureTaskNotArchived = (task) => {
+  if (task.isArchived) {
+    throw new ApiError(409, "Archived tasks cannot be modified through lifecycle routes");
   }
 };
 
@@ -114,56 +140,64 @@ const resolveTaskFeedQuery = (query, overrides = {}) => {
     search,
     requestedBy,
     assignedRunner,
+    archived,
     page = 1,
     limit = 20,
     sort = "desc",
     cursor,
   } = query;
 
-  const filters = {};
+  const conditions = [];
+  const resolvedStatus = overrides.status ?? status;
+  const resolvedCampus = overrides.campus ?? campus;
+  const resolvedTransportMode = overrides.transportMode ?? transportMode;
+  const resolvedArchived =
+    overrides.isArchived ??
+    (archived === undefined ? false : String(archived).toLowerCase() === "true");
 
-  const resolvedStatus = overrides.status || status;
+  conditions.push({ isArchived: resolvedArchived });
+
   if (resolvedStatus) {
     if (!allowedTaskStatuses.includes(resolvedStatus)) {
       throw new ApiError(400, "Invalid task status filter");
     }
 
-    filters.status = resolvedStatus;
+    conditions.push({ status: resolvedStatus });
   }
 
-  const resolvedCampus = overrides.campus || campus;
-  if (resolvedCampus) {
-    filters.campus = resolvedCampus.trim();
+  if (resolvedCampus?.trim()) {
+    conditions.push({ campus: resolvedCampus.trim() });
   }
 
-  const resolvedTransportMode = overrides.transportMode || transportMode;
   if (resolvedTransportMode) {
     if (!allowedTransportModes.includes(resolvedTransportMode)) {
       throw new ApiError(400, "Invalid transport mode filter");
     }
 
-    filters.transportMode = resolvedTransportMode;
+    conditions.push({ transportMode: resolvedTransportMode });
   }
 
   if (requestedBy) {
     ensureValidTaskId(requestedBy);
-    filters.requestedBy = requestedBy;
+    conditions.push({ requestedBy });
   }
 
   if (assignedRunner) {
     ensureValidTaskId(assignedRunner);
-    filters.assignedRunner = assignedRunner;
+    conditions.push({ assignedRunner });
   }
 
   if (search?.trim()) {
     const pattern = new RegExp(escapeRegex(search.trim()), "i");
-    filters.$or = [
-      { title: pattern },
-      { description: pattern },
-      { pickupLocation: pattern },
-      { dropoffLocation: pattern },
-      { campus: pattern },
-    ];
+    conditions.push({
+      $or: [
+        { title: pattern },
+        { description: pattern },
+        { pickupLocation: pattern },
+        { dropoffLocation: pattern },
+        { campus: pattern },
+      ],
+    });
   }
 
   const resolvedSort = String(sort).toLowerCase() === "asc" ? 1 : -1;
@@ -172,32 +206,28 @@ const resolveTaskFeedQuery = (query, overrides = {}) => {
   const decodedCursor = cursor ? decodeCursor(cursor) : null;
 
   if (decodedCursor) {
-    filters.$or = [
-      {
-        createdAt: resolvedSort === -1 ? { $lt: decodedCursor.createdAt } : { $gt: decodedCursor.createdAt },
-      },
-      {
-        createdAt: decodedCursor.createdAt,
-        _id: resolvedSort === -1 ? { $lt: decodedCursor.id } : { $gt: decodedCursor.id },
-      },
-    ];
-
-    if (search?.trim()) {
-      const pattern = new RegExp(escapeRegex(search.trim()), "i");
-      filters.$and = [
+    conditions.push({
+      $or: [
         {
-          $or: [
-            { title: pattern },
-            { description: pattern },
-            { pickupLocation: pattern },
-            { dropoffLocation: pattern },
-            { campus: pattern },
-          ],
+          createdAt:
+            resolvedSort === -1
+              ? { $lt: decodedCursor.createdAt }
+              : { $gt: decodedCursor.createdAt },
         },
-        { $or: filters.$or },
-      ];
-      delete filters.$or;
-    }
+        {
+          createdAt: decodedCursor.createdAt,
+          _id:
+            resolvedSort === -1 ? { $lt: decodedCursor.id } : { $gt: decodedCursor.id },
+        },
+      ],
+    });
+  }
+
+  let filters = {};
+  if (conditions.length === 1) {
+    [filters] = conditions;
+  } else if (conditions.length > 1) {
+    filters = { $and: conditions };
   }
 
   return {
@@ -214,7 +244,9 @@ const fetchTaskFeed = async (query, overrides = {}) => {
     resolveTaskFeedQuery(query, overrides);
 
   const sortOrder = { createdAt: resolvedSort, _id: resolvedSort };
-  const baseQuery = Task.find(filters).populate(populateTaskFields).sort(sortOrder);
+  const baseQuery = Task.find(filters)
+    .populate(detailedTaskPopulateFields)
+    .sort(sortOrder);
 
   if (usesCursor) {
     const tasks = await baseQuery.limit(resolvedLimit + 1);
@@ -266,13 +298,7 @@ const assertTransitionAllowed = (task, nextStatus) => {
 const fetchTaskOrThrow = async (taskId) => {
   ensureValidTaskId(taskId);
 
-  const task = await Task.findById(taskId).populate([
-    ...populateTaskFields,
-    {
-      path: "archivedBy",
-      select: "fullName email phoneNumber role isVerified isActive",
-    },
-  ]);
+  const task = await Task.findById(taskId).populate(detailedTaskPopulateFields);
 
   if (!task) {
     throw new ApiError(404, "Task not found");
@@ -281,15 +307,11 @@ const fetchTaskOrThrow = async (taskId) => {
   return task;
 };
 
-const ensureTaskNotArchived = (task) => {
-  if (task.isArchived) {
-    throw new ApiError(409, "Archived tasks cannot be modified through lifecycle routes");
-  }
 const fetchTaskForAssignment = async (taskId) => {
   ensureValidTaskId(taskId);
 
   const task = await Task.findById(taskId).select(
-    "requestedBy assignedRunner status acceptedAt",
+    "requestedBy assignedRunner status acceptedAt assignmentExpiresAt isArchived",
   );
 
   if (!task) {
@@ -320,7 +342,15 @@ const ensureTaskRequesterOrAdmin = (task, user) => {
 };
 
 const createTask = asyncHandler(async (req, res) => {
-  const { title, description, pickupLocation, dropoffLocation, campus, transportMode, reward } = req.body;
+  const {
+    title,
+    description,
+    pickupLocation,
+    dropoffLocation,
+    campus,
+    transportMode,
+    reward,
+  } = req.body;
 
   if (!title || !description || !pickupLocation || !dropoffLocation) {
     throw new ApiError(
@@ -349,44 +379,36 @@ const createTask = asyncHandler(async (req, res) => {
     requestedBy: req.user._id,
   });
 
-  const createdTask = await Task.findById(task._id).populate(populateTaskFields);
+  const createdTask = await Task.findById(task._id).populate(detailedTaskPopulateFields);
 
   res
     .status(201)
     .json(new ApiResponse(201, sanitizeTask(createdTask), "Task created successfully"));
 });
 
-const listOpenTasks = asyncHandler(async (_, res) => {
-  const tasks = await Task.find({ status: "open", isArchived: false })
-    .populate([
-      ...populateTaskFields,
-      {
-        path: "archivedBy",
-        select: "fullName email phoneNumber role isVerified isActive",
-      },
-    ])
-    .sort({ createdAt: -1 });
 const listOpenTasks = asyncHandler(async (req, res) => {
-  const { items, pagination } = await fetchTaskFeed(req.query, { status: "open" });
+  const { items, pagination } = await fetchTaskFeed(req.query, {
+    status: "open",
+    isArchived: false,
+  });
 
-  res
-    .status(200)
-    .json(
-      new ApiResponse(
-        200,
-        {
-          items: items.map(sanitizeTask),
-          pagination,
-          filters: {
-            search: req.query.search || "",
-            campus: req.query.campus || "",
-            status: "open",
-            transportMode: req.query.transportMode || "",
-          },
+  res.status(200).json(
+    new ApiResponse(
+      200,
+      {
+        items: items.map(sanitizeTask),
+        pagination,
+        filters: {
+          search: req.query.search || "",
+          campus: req.query.campus || "",
+          status: "open",
+          transportMode: req.query.transportMode || "",
+          archived: false,
         },
-        "Open tasks fetched successfully",
-      ),
-    );
+      },
+      "Open tasks fetched successfully",
+    ),
+  );
 });
 
 const listTasks = asyncHandler(async (req, res) => {
@@ -403,6 +425,10 @@ const listTasks = asyncHandler(async (req, res) => {
           campus: req.query.campus || "",
           status: req.query.status || "",
           transportMode: req.query.transportMode || "",
+          archived:
+            req.query.archived === undefined
+              ? false
+              : String(req.query.archived).toLowerCase() === "true",
         },
       },
       "Tasks fetched successfully",
@@ -422,8 +448,8 @@ const acceptTask = asyncHandler(async (req, res) => {
   const taskId = req.params.taskId;
   const existingTask = await fetchTaskForAssignment(taskId);
 
-  ensureTaskNotArchived(task);
-  assertTransitionAllowed(task, "accepted");
+  ensureTaskNotArchived(existingTask);
+
   if (String(existingTask.requestedBy) === String(req.user._id)) {
     throw new ApiError(403, "Requesters cannot accept their own task");
   }
@@ -440,6 +466,7 @@ const acceptTask = asyncHandler(async (req, res) => {
   }
 
   const acceptedAt = new Date();
+  const assignmentExpiresAt = calculateAssignmentExpiryDate(acceptedAt);
 
   const task = await Task.findOneAndUpdate(
     {
@@ -447,12 +474,14 @@ const acceptTask = asyncHandler(async (req, res) => {
       requestedBy: { $ne: req.user._id },
       assignedRunner: null,
       status: "open",
+      isArchived: false,
     },
     {
       $set: {
         status: "accepted",
         assignedRunner: req.user._id,
         acceptedAt,
+        assignmentExpiresAt,
         startedAt: null,
         completedAt: null,
         cancelledAt: null,
@@ -462,7 +491,7 @@ const acceptTask = asyncHandler(async (req, res) => {
     {
       returnDocument: "after",
     },
-  ).populate(populateTaskFields);
+  ).populate(detailedTaskPopulateFields);
 
   if (!task) {
     throw new ApiError(409, "Task acceptance failed because it was already taken");
@@ -482,9 +511,10 @@ const markTaskInProgress = asyncHandler(async (req, res) => {
 
   task.status = "in_progress";
   task.startedAt = new Date();
+  task.assignmentExpiresAt = null;
 
   await task.save();
-  await task.populate(populateTaskFields);
+  await task.populate(detailedTaskPopulateFields);
 
   res.status(200).json(
     new ApiResponse(200, sanitizeTask(task), "Task marked as in progress successfully"),
@@ -500,9 +530,10 @@ const completeTask = asyncHandler(async (req, res) => {
 
   task.status = "completed";
   task.completedAt = new Date();
+  task.assignmentExpiresAt = null;
 
   await task.save();
-  await task.populate(populateTaskFields);
+  await task.populate(detailedTaskPopulateFields);
 
   res
     .status(200)
@@ -520,9 +551,10 @@ const cancelTask = asyncHandler(async (req, res) => {
   task.status = "cancelled";
   task.cancelledAt = new Date();
   task.cancellationReason = cancellationReason?.trim() || "Cancelled by requester";
+  task.assignmentExpiresAt = null;
 
   await task.save();
-  await task.populate(populateTaskFields);
+  await task.populate(detailedTaskPopulateFields);
 
   res
     .status(200)
@@ -534,9 +566,15 @@ const listProtectedTaskActions = asyncHandler(async (req, res) => {
     req.user.role === "requester"
       ? ["create-task", "list-open-tasks", "cancel-own-task"]
       : req.user.role === "runner"
-        ? ["list-open-tasks", "accept-task", "mark-task-in-progress", "complete-task"]
+        ? [
+            "list-open-tasks",
+            "accept-task",
+            "mark-task-in-progress",
+            "complete-task",
+          ]
         : [
             "create-task",
+            "list-all-tasks",
             "list-open-tasks",
             "accept-task",
             "mark-task-in-progress",

--- a/backend/src/docs/swagger.js
+++ b/backend/src/docs/swagger.js
@@ -69,6 +69,9 @@ const taskSchema = {
     acceptedAt: {
       anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
     },
+    assignmentExpiresAt: {
+      anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+    },
     startedAt: {
       anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
     },
@@ -79,6 +82,17 @@ const taskSchema = {
       anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
     },
     cancellationReason: { type: "string", example: "Requester no longer needs the task" },
+    lastExpiredAt: {
+      anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+    },
+    reopenedAt: {
+      anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+    },
+    expiryReopenCount: { type: "integer", example: 1 },
+    expirationReason: {
+      type: "string",
+      example: "Task acceptance expired after 900000ms",
+    },
     createdAt: { type: "string", format: "date-time" },
     updatedAt: { type: "string", format: "date-time" },
   },
@@ -172,8 +186,7 @@ const swaggerDocument = {
     title: "Campus Runner Backend API",
     version: "1.0.0",
     description:
-      "JWT authentication, role-based authorization, profile, task, wallet, and admin moderation APIs for Campus Runner.",
-      "JWT authentication, role-based authorization, profile APIs, task lifecycle APIs, and wallet APIs for Campus Runner.",
+      "JWT authentication, role-based authorization, profile, task, wallet, admin moderation, and background task expiry APIs for Campus Runner.",
   },
   servers: [
     {
@@ -1012,21 +1025,11 @@ const swaggerDocument = {
         responses: {
           200: {
             description: "Task accepted successfully",
-          },
-        },
-      },
-    },
-    "/api/v1/tasks/{taskId}/in-progress": {
-      patch: {
-        tags: ["Tasks"],
-        summary: "Mark an accepted task as in progress",
-        security: [{ bearerAuth: [] }],
-        parameters: [
-          {
-            in: "path",
-            name: "taskId",
-            required: true,
-            schema: { type: "string" },
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TaskResponse" },
+              },
+            },
           },
           403: {
             description: "Requester cannot accept their own task",
@@ -1348,7 +1351,6 @@ const swaggerDocument = {
           {
             in: "path",
             name: "reportId",
-            name: "transactionId",
             required: true,
             schema: { type: "string" },
           },
@@ -1358,7 +1360,6 @@ const swaggerDocument = {
           content: {
             "application/json": {
               schema: { $ref: "#/components/schemas/UpdateReportStatusRequest" },
-              schema: { $ref: "#/components/schemas/UpdateWalletTransactionStatusRequest" },
             },
           },
         },
@@ -1370,7 +1371,6 @@ const swaggerDocument = {
                 schema: { $ref: "#/components/schemas/ReportResponse" },
               },
             },
-            description: "Wallet transaction status updated successfully",
           },
         },
       },

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,4 +1,5 @@
 import { app } from "./app.js";
+import { startTaskExpiryMonitor } from "./background/taskExpiry.monitor.js";
 import connectDB from "./db/db.js";
 import { validateEnv } from "./utils/env.js";
 
@@ -8,6 +9,8 @@ validateEnv();
 
 connectDB()
 .then(() =>{
+    startTaskExpiryMonitor();
+
    app.on("error", (error) => {
       console.log("ERRR", error);
       throw error

--- a/backend/src/models/task.model.js
+++ b/backend/src/models/task.model.js
@@ -71,6 +71,11 @@ const taskSchema = new mongoose.Schema(
       type: Date,
       default: null,
     },
+    assignmentExpiresAt: {
+      type: Date,
+      default: null,
+      index: true,
+    },
     startedAt: {
       type: Date,
       default: null,
@@ -84,6 +89,24 @@ const taskSchema = new mongoose.Schema(
       default: null,
     },
     cancellationReason: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    lastExpiredAt: {
+      type: Date,
+      default: null,
+    },
+    reopenedAt: {
+      type: Date,
+      default: null,
+    },
+    expiryReopenCount: {
+      type: Number,
+      min: 0,
+      default: 0,
+    },
+    expirationReason: {
       type: String,
       trim: true,
       default: "",
@@ -114,6 +137,7 @@ const taskSchema = new mongoose.Schema(
 );
 
 taskSchema.index({ status: 1, createdAt: -1 });
+taskSchema.index({ status: 1, assignmentExpiresAt: 1, isArchived: 1 });
 taskSchema.index({ isArchived: 1, status: 1, createdAt: -1 });
 taskSchema.index({ campus: 1, status: 1, createdAt: -1 });
 taskSchema.index({ transportMode: 1, status: 1, createdAt: -1 });

--- a/backend/src/models/user.model.js
+++ b/backend/src/models/user.model.js
@@ -77,14 +77,12 @@ const userSchema = new mongoose.Schema(
   },
 );
 
-userSchema.pre("save", async function save(next) {
+userSchema.pre("save", async function save() {
   if (!this.isModified("password")) {
-    next();
     return;
   }
 
   this.password = await bcrypt.hash(this.password, 10);
-  next();
 });
 
 userSchema.methods.isPasswordCorrect = async function isPasswordCorrect(

--- a/backend/test/task-acceptance-race.test.js
+++ b/backend/test/task-acceptance-race.test.js
@@ -33,9 +33,7 @@ const createAccessToken = (user) =>
   );
 
 const createUser = async ({ fullName, email, role }) => {
-  const now = new Date();
-  const user = {
-    _id: new mongoose.Types.ObjectId(),
+  return User.create({
     fullName,
     email,
     password: "Password123!",
@@ -43,14 +41,9 @@ const createUser = async ({ fullName, email, role }) => {
     isVerified: true,
     isActive: true,
     phoneNumber: "",
-    refreshToken: null,
-    createdAt: now,
-    updatedAt: now,
-  };
-
-  await User.collection.insertOne(user);
-
-  return user;
+    campusId: "",
+    campusName: "",
+  });
 };
 
 describe("task acceptance concurrency", () => {

--- a/backend/test/task-expiry.monitor.test.js
+++ b/backend/test/task-expiry.monitor.test.js
@@ -1,0 +1,129 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+process.env.NODE_ENV = "test";
+
+const [{ reopenExpiredAcceptedTasks }, { Task }, { User }] = await Promise.all([
+  import("../src/background/taskExpiry.monitor.js"),
+  import("../src/models/task.model.js"),
+  import("../src/models/user.model.js"),
+]);
+
+const createUser = async ({ fullName, email, role }) => {
+  return User.create({
+    fullName,
+    email,
+    password: "Password123!",
+    role,
+    isVerified: true,
+    isActive: true,
+    phoneNumber: "",
+    campusId: "",
+    campusName: "",
+  });
+};
+
+describe("task expiry monitor", () => {
+  let mongoServer;
+
+  before(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri(), {
+      dbName: "campus-runner-task-expiry-tests",
+    });
+  });
+
+  after(async () => {
+    await mongoose.disconnect();
+
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
+  beforeEach(async () => {
+    await Promise.all([User.deleteMany({}), Task.deleteMany({})]);
+  });
+
+  it("reopens stale accepted tasks and keeps fresh assignments untouched", async () => {
+    const requester = await createUser({
+      fullName: "Requester",
+      email: "expiry-requester@example.com",
+      role: "requester",
+    });
+
+    const [staleRunner, freshRunner] = await Promise.all([
+      createUser({
+        fullName: "Stale Runner",
+        email: "stale-runner@example.com",
+        role: "runner",
+      }),
+      createUser({
+        fullName: "Fresh Runner",
+        email: "fresh-runner@example.com",
+        role: "runner",
+      }),
+    ]);
+
+    const now = new Date("2026-03-08T12:00:00.000Z");
+    const staleAcceptedAt = new Date(now.getTime() - 16 * 60 * 1000);
+    const freshAcceptedAt = new Date(now.getTime() - 5 * 60 * 1000);
+
+    const [staleTask, freshTask] = await Task.create([
+      {
+        title: "Expired accepted task",
+        description: "This task should be reopened",
+        pickupLocation: "Block A",
+        dropoffLocation: "Block B",
+        reward: 100,
+        requestedBy: requester._id,
+        assignedRunner: staleRunner._id,
+        status: "accepted",
+        acceptedAt: staleAcceptedAt,
+        assignmentExpiresAt: new Date(now.getTime() - 60 * 1000),
+      },
+      {
+        title: "Fresh accepted task",
+        description: "This task should remain accepted",
+        pickupLocation: "Library",
+        dropoffLocation: "Hostel",
+        reward: 120,
+        requestedBy: requester._id,
+        assignedRunner: freshRunner._id,
+        status: "accepted",
+        acceptedAt: freshAcceptedAt,
+        assignmentExpiresAt: new Date(now.getTime() + 10 * 60 * 1000),
+      },
+    ]);
+
+    const result = await reopenExpiredAcceptedTasks({
+      now,
+      acceptanceTimeoutMs: 15 * 60 * 1000,
+    });
+
+    assert.equal(result.reopenedCount, 1);
+
+    const [updatedStaleTask, updatedFreshTask] = await Promise.all([
+      Task.findById(staleTask._id).lean(),
+      Task.findById(freshTask._id).lean(),
+    ]);
+
+    assert.ok(updatedStaleTask);
+    assert.equal(updatedStaleTask.status, "open");
+    assert.equal(updatedStaleTask.assignedRunner, null);
+    assert.equal(updatedStaleTask.acceptedAt, null);
+    assert.equal(updatedStaleTask.assignmentExpiresAt, null);
+    assert.equal(updatedStaleTask.expiryReopenCount, 1);
+    assert.equal(updatedStaleTask.reopenedAt?.toISOString(), now.toISOString());
+    assert.equal(updatedStaleTask.lastExpiredAt?.toISOString(), now.toISOString());
+    assert.match(updatedStaleTask.expirationReason, /expired/i);
+
+    assert.ok(updatedFreshTask);
+    assert.equal(updatedFreshTask.status, "accepted");
+    assert.equal(updatedFreshTask.assignedRunner?.toString(), freshRunner._id.toString());
+    assert.equal(updatedFreshTask.expiryReopenCount, 0);
+  });
+});


### PR DESCRIPTION
#89  solved 


This PR adds backend support for task expiry and automatic reopening of stale accepted tasks so assignments do not remain blocked indefinitely when a runner fails to move a task into progress within the configured time window. It introduces background monitoring that periodically checks accepted tasks, reopens expired ones by clearing runner assignment and resetting lifecycle state, and records expiry metadata such as reopen count and last expired time for traceability. Alongside that feature, it fixes existing backend issues in the task controller, Swagger documentation, and user save hook, preserves the atomic task acceptance flow, and adds integration tests covering both concurrent runner acceptance and stale task auto-reopen behavior to validate the lifecycle end to end.

