### PR TITLE
Runner Earnings Settlement API

### DIFF
--- a/backend/src/controllers/task.controller.js
+++ b/backend/src/controllers/task.controller.js
@@ -6,6 +6,7 @@ import {
   allowedTransportModes,
   Task,
 } from "../models/task.model.js";
+import { settleRunnerEarningsForTask } from "../services/taskSettlement.service.js";
 import { ApiError } from "../utils/ApiError.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
@@ -71,6 +72,11 @@ const sanitizeTask = (task) => ({
   assignmentExpiresAt: task.assignmentExpiresAt,
   startedAt: task.startedAt,
   completedAt: task.completedAt,
+  settlementStatus: task.settlementStatus,
+  settlementAmount: task.settlementAmount,
+  settlementReference: task.settlementReference,
+  settlementTransactionId: task.settlementTransaction?._id || task.settlementTransaction || null,
+  settledAt: task.settledAt,
   cancelledAt: task.cancelledAt,
   cancellationReason: task.cancellationReason,
   lastExpiredAt: task.lastExpiredAt,
@@ -533,11 +539,18 @@ const completeTask = asyncHandler(async (req, res) => {
   task.assignmentExpiresAt = null;
 
   await task.save();
-  await task.populate(detailedTaskPopulateFields);
+  const settlementResult = await settleRunnerEarningsForTask({
+    taskId: task._id,
+    initiatedBy: req.user._id,
+  });
+
+  const settledTask = await Task.findById(settlementResult.task._id).populate(
+    detailedTaskPopulateFields,
+  );
 
   res
     .status(200)
-    .json(new ApiResponse(200, sanitizeTask(task), "Task completed successfully"));
+    .json(new ApiResponse(200, sanitizeTask(settledTask), "Task completed successfully"));
 });
 
 const cancelTask = asyncHandler(async (req, res) => {

--- a/backend/src/controllers/wallet.controller.js
+++ b/backend/src/controllers/wallet.controller.js
@@ -50,6 +50,7 @@ const sanitizeTransaction = (transaction) => ({
   status: transaction.status,
   description: transaction.description,
   reference: transaction.reference,
+  sourceTaskId: transaction.sourceTask?._id || transaction.sourceTask || null,
   failureReason: transaction.failureReason,
   initiatedBy: sanitizeWalletUser(transaction.initiatedBy),
   createdAt: transaction.createdAt,
@@ -214,6 +215,7 @@ const createWalletTransaction = async ({
     description: description.trim(),
     reference: reference?.trim() || "",
     status: status || "completed",
+    sourceTask: null,
     initiatedBy,
     failureReason: status === "failed" ? "Marked failed at creation" : "",
   });

--- a/backend/src/docs/swagger.js
+++ b/backend/src/docs/swagger.js
@@ -78,6 +78,23 @@ const taskSchema = {
     completedAt: {
       anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
     },
+    settlementStatus: {
+      type: "string",
+      enum: ["pending", "settled", "not_required"],
+      example: "settled",
+    },
+    settlementAmount: { type: "number", example: 80 },
+    settlementReference: {
+      type: "string",
+      example: "TASK-SETTLEMENT-67ca72d999ea40f2abc98765",
+    },
+    settlementTransactionId: {
+      anyOf: [{ type: "string" }, { type: "null" }],
+      example: "67ca72d999ea40f2abc45678",
+    },
+    settledAt: {
+      anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+    },
     cancelledAt: {
       anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
     },
@@ -115,6 +132,10 @@ const walletTransactionSchema = {
       example: "Manual payout credit for completed campus task",
     },
     reference: { type: "string", example: "TASK-PAYOUT-001" },
+    sourceTaskId: {
+      anyOf: [{ type: "string" }, { type: "null" }],
+      example: "67ca72d999ea40f2abc98765",
+    },
     failureReason: { type: "string", example: "Bank transfer rejected" },
     initiatedBy: {
       anyOf: [{ $ref: "#/components/schemas/User" }, { type: "null" }],

--- a/backend/src/models/task.model.js
+++ b/backend/src/models/task.model.js
@@ -84,6 +84,31 @@ const taskSchema = new mongoose.Schema(
       type: Date,
       default: null,
     },
+    settlementStatus: {
+      type: String,
+      enum: ["pending", "settled", "not_required"],
+      default: "pending",
+      index: true,
+    },
+    settlementAmount: {
+      type: Number,
+      min: 0,
+      default: 0,
+    },
+    settlementReference: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    settlementTransaction: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "WalletTransaction",
+      default: null,
+    },
+    settledAt: {
+      type: Date,
+      default: null,
+    },
     cancelledAt: {
       type: Date,
       default: null,
@@ -138,6 +163,7 @@ const taskSchema = new mongoose.Schema(
 
 taskSchema.index({ status: 1, createdAt: -1 });
 taskSchema.index({ status: 1, assignmentExpiresAt: 1, isArchived: 1 });
+taskSchema.index({ settlementStatus: 1, completedAt: -1 });
 taskSchema.index({ isArchived: 1, status: 1, createdAt: -1 });
 taskSchema.index({ campus: 1, status: 1, createdAt: -1 });
 taskSchema.index({ transportMode: 1, status: 1, createdAt: -1 });

--- a/backend/src/models/walletTransaction.model.js
+++ b/backend/src/models/walletTransaction.model.js
@@ -38,6 +38,11 @@ const walletTransactionSchema = new mongoose.Schema(
       trim: true,
       default: "",
     },
+    sourceTask: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Task",
+      default: null,
+    },
     failureReason: {
       type: String,
       trim: true,
@@ -56,6 +61,16 @@ const walletTransactionSchema = new mongoose.Schema(
 
 walletTransactionSchema.index({ user: 1, createdAt: -1 });
 walletTransactionSchema.index({ user: 1, status: 1, createdAt: -1 });
+walletTransactionSchema.index(
+  { sourceTask: 1, type: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      sourceTask: { $type: "objectId" },
+      type: "credit",
+    },
+  },
+);
 
 const WalletTransaction = mongoose.model(
   "WalletTransaction",

--- a/backend/src/services/taskSettlement.service.js
+++ b/backend/src/services/taskSettlement.service.js
@@ -1,0 +1,109 @@
+import { Task } from "../models/task.model.js";
+import { WalletTransaction } from "../models/walletTransaction.model.js";
+import { ApiError } from "../utils/ApiError.js";
+
+const buildSettlementReference = (taskId) => `TASK-SETTLEMENT-${taskId}`;
+
+const settleRunnerEarningsForTask = async ({ taskId, initiatedBy }) => {
+  const task = await Task.findById(taskId).populate("assignedRunner", "_id");
+
+  if (!task) {
+    throw new ApiError(404, "Task not found for settlement");
+  }
+
+  if (task.status !== "completed") {
+    throw new ApiError(409, "Only completed tasks can be settled");
+  }
+
+  if (!task.assignedRunner) {
+    throw new ApiError(409, "Completed task has no assigned runner for settlement");
+  }
+
+  if (task.settlementStatus === "settled" && task.settlementTransaction) {
+    const existingTransaction = await WalletTransaction.findById(task.settlementTransaction);
+
+    return {
+      task,
+      transaction: existingTransaction,
+      created: false,
+    };
+  }
+
+  if (task.reward <= 0) {
+    task.settlementStatus = "not_required";
+    task.settlementAmount = 0;
+    task.settlementReference = "";
+    task.settlementTransaction = null;
+    task.settledAt = task.settledAt || new Date();
+    await task.save();
+
+    return {
+      task,
+      transaction: null,
+      created: false,
+    };
+  }
+
+  const settlementReference = buildSettlementReference(task._id);
+  const settlementPayload = {
+    user: task.assignedRunner._id,
+    type: "credit",
+    amount: task.reward,
+    status: "completed",
+    description: `Automatic payout for completed task: ${task.title}`,
+    reference: settlementReference,
+    sourceTask: task._id,
+    initiatedBy: initiatedBy || task.assignedRunner._id,
+    failureReason: "",
+  };
+
+  let transaction = await WalletTransaction.findOne({
+    sourceTask: task._id,
+    type: "credit",
+  });
+  let created = false;
+
+  if (!transaction) {
+    try {
+      transaction = await WalletTransaction.findOneAndUpdate(
+        {
+          sourceTask: task._id,
+          type: "credit",
+        },
+        {
+          $setOnInsert: settlementPayload,
+        },
+        {
+          upsert: true,
+          returnDocument: "after",
+        },
+      );
+      created = true;
+    } catch (error) {
+      if (error?.code !== 11000) {
+        throw error;
+      }
+
+      transaction = await WalletTransaction.findOne({
+        sourceTask: task._id,
+        type: "credit",
+      });
+    }
+  }
+
+  task.settlementStatus = "settled";
+  task.settlementAmount = task.reward;
+  task.settlementReference = settlementReference;
+  task.settlementTransaction = transaction?._id || null;
+  task.settledAt = task.settledAt || transaction?.createdAt || new Date();
+
+  await task.save();
+
+  return {
+    task,
+    transaction,
+    created,
+  };
+};
+
+export { buildSettlementReference, settleRunnerEarningsForTask };

--- a/backend/test/task-settlement.test.js
+++ b/backend/test/task-settlement.test.js
@@ -1,0 +1,142 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+process.env.ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET || "test-access-secret";
+process.env.REFRESH_TOKEN_SECRET =
+  process.env.REFRESH_TOKEN_SECRET || "test-refresh-secret";
+process.env.CORS_ORIGIN = process.env.CORS_ORIGIN || "http://localhost:3000";
+process.env.MONGODB_URI = process.env.MONGODB_URI || "mongodb://127.0.0.1:27017";
+
+const [{ app }, { Task }, { User }, { WalletTransaction }, { settleRunnerEarningsForTask }] =
+  await Promise.all([
+    import("../src/app.js"),
+    import("../src/models/task.model.js"),
+    import("../src/models/user.model.js"),
+    import("../src/models/walletTransaction.model.js"),
+    import("../src/services/taskSettlement.service.js"),
+  ]);
+
+const createAccessToken = (user) =>
+  jwt.sign(
+    {
+      _id: user._id.toString(),
+      email: user.email,
+      role: user.role,
+    },
+    process.env.ACCESS_TOKEN_SECRET,
+    {
+      expiresIn: "1h",
+    },
+  );
+
+const createUser = async ({ fullName, email, role }) => {
+  return User.create({
+    fullName,
+    email,
+    password: "Password123!",
+    role,
+    isVerified: true,
+    isActive: true,
+    phoneNumber: "",
+    campusId: "",
+    campusName: "",
+  });
+};
+
+describe("runner earnings settlement", () => {
+  let mongoServer;
+
+  before(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri(), {
+      dbName: "campus-runner-settlement-tests",
+    });
+  });
+
+  after(async () => {
+    await mongoose.disconnect();
+
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      User.deleteMany({}),
+      Task.deleteMany({}),
+      WalletTransaction.deleteMany({}),
+    ]);
+  });
+
+  it("credits the runner wallet when a task is completed and prevents duplicate settlement", async () => {
+    const requester = await createUser({
+      fullName: "Requester",
+      email: "settlement-requester@example.com",
+      role: "requester",
+    });
+    const runner = await createUser({
+      fullName: "Runner",
+      email: "settlement-runner@example.com",
+      role: "runner",
+    });
+
+    const task = await Task.create({
+      title: "Deliver package",
+      description: "Take parcel to hostel reception",
+      pickupLocation: "Block C",
+      dropoffLocation: "Hostel Reception",
+      reward: 175,
+      requestedBy: requester._id,
+      assignedRunner: runner._id,
+      status: "in_progress",
+      acceptedAt: new Date("2026-03-08T11:00:00.000Z"),
+      startedAt: new Date("2026-03-08T11:15:00.000Z"),
+    });
+
+    const completeResponse = await request(app)
+      .patch(`/api/v1/tasks/${task._id}/complete`)
+      .set("Authorization", `Bearer ${createAccessToken(runner)}`);
+
+    assert.equal(completeResponse.status, 200);
+    assert.equal(completeResponse.body.success, true);
+    assert.equal(completeResponse.body.data.status, "completed");
+    assert.equal(completeResponse.body.data.settlementStatus, "settled");
+    assert.equal(completeResponse.body.data.settlementAmount, 175);
+    assert.match(completeResponse.body.data.settlementReference, /^TASK-SETTLEMENT-/);
+    assert.ok(completeResponse.body.data.settledAt);
+
+    const transactionsAfterCompletion = await WalletTransaction.find({
+      sourceTask: task._id,
+      type: "credit",
+    }).lean();
+
+    assert.equal(transactionsAfterCompletion.length, 1);
+    assert.equal(transactionsAfterCompletion[0].user.toString(), runner._id.toString());
+    assert.equal(transactionsAfterCompletion[0].amount, 175);
+    assert.equal(transactionsAfterCompletion[0].status, "completed");
+
+    const secondSettlement = await settleRunnerEarningsForTask({
+      taskId: task._id,
+      initiatedBy: runner._id,
+    });
+
+    const transactionsAfterRetry = await WalletTransaction.find({
+      sourceTask: task._id,
+      type: "credit",
+    }).lean();
+    const updatedTask = await Task.findById(task._id).lean();
+
+    assert.equal(secondSettlement.created, false);
+    assert.equal(transactionsAfterRetry.length, 1);
+    assert.equal(updatedTask.settlementStatus, "settled");
+    assert.equal(updatedTask.settlementAmount, 175);
+    assert.ok(updatedTask.settlementTransaction);
+  });
+});


### PR DESCRIPTION
#90 solved 


This PR adds a backend-only runner earnings settlement flow that automatically credits a runner’s wallet when a task is completed, records the payout as a wallet transaction, and prevents duplicate settlement for the same task. The implementation introduces settlement metadata on tasks, links wallet transactions back to their source task for idempotency, and wires task completion to a dedicated settlement service so payout creation happens consistently as part of the lifecycle. It also updates backend response payloads and Swagger documentation to expose settlement details, and adds integration coverage to verify that task completion creates exactly one credit transaction and that repeated settlement attempts do not generate duplicate payouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task settlement tracking: Completed tasks now automatically settle runner earnings with visible settlement status, amount, reference, and date.
  * Wallet transaction improvements: Transactions now track their associated source task for better traceability.

* **Tests**
  * Added comprehensive integration tests for task settlement workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->