### PR TITLE
tasks dispute api

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,6 +8,7 @@ import { swaggerDocument } from "./docs/swagger.js";
 import { errorHandler } from "./middlewares/error.middleware.js";
 import adminRouter from "./routes/admin.routes.js";
 import authRouter from "./routes/auth.routes.js";
+import disputeRouter from "./routes/dispute.routes.js";
 import profileRouter from "./routes/profile.routes.js";
 import taskRouter from "./routes/task.routes.js";
 import walletRouter from "./routes/wallet.routes.js";
@@ -44,6 +45,7 @@ app.get("/api/v1/health", (_, res) => {
 
 app.use("/api/v1/auth", authRouter)
 app.use("/api/v1/admin", adminRouter)
+app.use("/api/v1/disputes", disputeRouter)
 app.use("/api/v1/profile", profileRouter)
 app.use("/api/v1/tasks", taskRouter)
 app.use("/api/v1/wallet", walletRouter)

--- a/backend/src/controllers/dispute.controller.js
+++ b/backend/src/controllers/dispute.controller.js
@@ -1,0 +1,366 @@
+import mongoose from "mongoose";
+
+import {
+  allowedDisputeStatuses,
+  Dispute,
+} from "../models/dispute.model.js";
+import { Task } from "../models/task.model.js";
+import { ApiError } from "../utils/ApiError.js";
+import { ApiResponse } from "../utils/ApiResponse.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+
+const disputePopulateFields = [
+  {
+    path: "openedBy",
+    select: "fullName email phoneNumber role isVerified isActive",
+  },
+  {
+    path: "reviewedBy",
+    select: "fullName email phoneNumber role isVerified isActive",
+  },
+  {
+    path: "task",
+    populate: [
+      {
+        path: "requestedBy",
+        select: "fullName email phoneNumber role isVerified isActive",
+      },
+      {
+        path: "assignedRunner",
+        select: "fullName email phoneNumber role isVerified isActive",
+      },
+      {
+        path: "archivedBy",
+        select: "fullName email phoneNumber role isVerified isActive",
+      },
+    ],
+  },
+];
+
+const sanitizeUser = (user) => {
+  if (!user) {
+    return null;
+  }
+
+  return {
+    id: user._id,
+    fullName: user.fullName,
+    email: user.email,
+    phoneNumber: user.phoneNumber,
+    role: user.role,
+    isVerified: user.isVerified,
+    isActive: user.isActive,
+  };
+};
+
+const sanitizeTask = (task) => {
+  if (!task) {
+    return null;
+  }
+
+  return {
+    id: task._id,
+    title: task.title,
+    description: task.description,
+    pickupLocation: task.pickupLocation,
+    dropoffLocation: task.dropoffLocation,
+    reward: task.reward,
+    status: task.status,
+    requestedBy: sanitizeUser(task.requestedBy),
+    assignedRunner: sanitizeUser(task.assignedRunner),
+    isArchived: task.isArchived,
+    archivedAt: task.archivedAt,
+    archiveReason: task.archiveReason,
+    archivedBy: sanitizeUser(task.archivedBy),
+    completedAt: task.completedAt,
+    cancelledAt: task.cancelledAt,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+  };
+};
+
+const sanitizeEvidence = (evidence = []) => {
+  return evidence.map((item) => ({
+    type: item.type,
+    label: item.label,
+    url: item.url,
+    note: item.note,
+  }));
+};
+
+const sanitizeDispute = (dispute) => ({
+  id: dispute._id,
+  task: sanitizeTask(dispute.task),
+  openedBy: sanitizeUser(dispute.openedBy),
+  openedByRole: dispute.openedByRole,
+  reason: dispute.reason,
+  details: dispute.details,
+  evidence: sanitizeEvidence(dispute.evidence),
+  status: dispute.status,
+  resolutionNote: dispute.resolutionNote,
+  reviewedBy: sanitizeUser(dispute.reviewedBy),
+  reviewedAt: dispute.reviewedAt,
+  createdAt: dispute.createdAt,
+  updatedAt: dispute.updatedAt,
+});
+
+const ensureValidObjectId = (value, fieldName) => {
+  if (!mongoose.isValidObjectId(value)) {
+    throw new ApiError(400, `Invalid ${fieldName} provided`);
+  }
+};
+
+const normalizeEvidence = (evidence) => {
+  if (evidence === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(evidence)) {
+    throw new ApiError(400, "evidence must be an array when provided");
+  }
+
+  return evidence.map((item, index) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new ApiError(400, `evidence[${index}] must be an object`);
+    }
+
+    return {
+      type: item.type?.trim() || "link",
+      label: item.label?.trim() || "",
+      url: item.url?.trim() || "",
+      note: item.note?.trim() || "",
+    };
+  });
+};
+
+const ensureTaskParticipantRole = (task, user) => {
+  if (task.requestedBy && String(task.requestedBy._id) === String(user._id)) {
+    return "requester";
+  }
+
+  if (task.assignedRunner && String(task.assignedRunner._id) === String(user._id)) {
+    return "runner";
+  }
+
+  throw new ApiError(403, "Only the requester or assigned runner can open a dispute for this task");
+};
+
+const ensureDisputeReadableByUser = (dispute, user) => {
+  if (user.role === "admin") {
+    return;
+  }
+
+  const task = dispute.task;
+  const isOpenedByUser = String(dispute.openedBy._id) === String(user._id);
+  const isRequester = task?.requestedBy && String(task.requestedBy._id) === String(user._id);
+  const isAssignedRunner =
+    task?.assignedRunner && String(task.assignedRunner._id) === String(user._id);
+
+  if (!isOpenedByUser && !isRequester && !isAssignedRunner) {
+    throw new ApiError(403, "You are not allowed to access this dispute");
+  }
+};
+
+const createDispute = asyncHandler(async (req, res) => {
+  const { taskId, reason, details, evidence } = req.body;
+
+  ensureValidObjectId(taskId, "task id");
+
+  if (!reason || !reason.trim()) {
+    throw new ApiError(400, "reason is required");
+  }
+
+  const task = await Task.findById(taskId)
+    .populate("requestedBy", "fullName email phoneNumber role isVerified isActive")
+    .populate("assignedRunner", "fullName email phoneNumber role isVerified isActive")
+    .populate("archivedBy", "fullName email phoneNumber role isVerified isActive");
+
+  if (!task) {
+    throw new ApiError(404, "Task not found");
+  }
+
+  if (!["completed", "cancelled"].includes(task.status)) {
+    throw new ApiError(409, "Disputes can only be opened for completed or cancelled tasks");
+  }
+
+  const openedByRole = ensureTaskParticipantRole(task, req.user);
+
+  const existingDispute = await Dispute.findOne({
+    task: taskId,
+    openedBy: req.user._id,
+  });
+
+  if (existingDispute) {
+    throw new ApiError(409, "You have already opened a dispute for this task");
+  }
+
+  const dispute = await Dispute.create({
+    task: taskId,
+    openedBy: req.user._id,
+    openedByRole,
+    reason: reason.trim(),
+    details: details?.trim() || "",
+    evidence: normalizeEvidence(evidence),
+  });
+
+  const createdDispute = await Dispute.findById(dispute._id).populate(disputePopulateFields);
+
+  res.status(201).json(
+    new ApiResponse(201, sanitizeDispute(createdDispute), "Dispute opened successfully"),
+  );
+});
+
+const listMyDisputes = asyncHandler(async (req, res) => {
+  const { status, page = 1, limit = 20 } = req.query;
+
+  const filters = { openedBy: req.user._id };
+  const resolvedPage = Math.max(Number(page) || 1, 1);
+  const resolvedLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
+
+  if (status) {
+    if (!allowedDisputeStatuses.includes(status)) {
+      throw new ApiError(400, "Invalid dispute status filter");
+    }
+
+    filters.status = status;
+  }
+
+  const [disputes, total] = await Promise.all([
+    Dispute.find(filters)
+      .populate(disputePopulateFields)
+      .sort({ createdAt: -1 })
+      .skip((resolvedPage - 1) * resolvedLimit)
+      .limit(resolvedLimit),
+    Dispute.countDocuments(filters),
+  ]);
+
+  res.status(200).json(
+    new ApiResponse(
+      200,
+      {
+        items: disputes.map(sanitizeDispute),
+        pagination: {
+          page: resolvedPage,
+          limit: resolvedLimit,
+          total,
+          totalPages: Math.ceil(total / resolvedLimit) || 1,
+        },
+        filters: {
+          status: status || "",
+        },
+      },
+      "Disputes fetched successfully",
+    ),
+  );
+});
+
+const getDisputeById = asyncHandler(async (req, res) => {
+  const { disputeId } = req.params;
+  ensureValidObjectId(disputeId, "dispute id");
+
+  const dispute = await Dispute.findById(disputeId).populate(disputePopulateFields);
+
+  if (!dispute) {
+    throw new ApiError(404, "Dispute not found");
+  }
+
+  ensureDisputeReadableByUser(dispute, req.user);
+
+  res.status(200).json(
+    new ApiResponse(200, sanitizeDispute(dispute), "Dispute fetched successfully"),
+  );
+});
+
+const listAllDisputes = asyncHandler(async (req, res) => {
+  const { status, openedByRole, taskId, page = 1, limit = 20 } = req.query;
+  const filters = {};
+  const resolvedPage = Math.max(Number(page) || 1, 1);
+  const resolvedLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
+
+  if (status) {
+    if (!allowedDisputeStatuses.includes(status)) {
+      throw new ApiError(400, "Invalid dispute status filter");
+    }
+
+    filters.status = status;
+  }
+
+  if (openedByRole) {
+    if (!["requester", "runner"].includes(openedByRole)) {
+      throw new ApiError(400, "Invalid dispute openedByRole filter");
+    }
+
+    filters.openedByRole = openedByRole;
+  }
+
+  if (taskId) {
+    ensureValidObjectId(taskId, "task id");
+    filters.task = taskId;
+  }
+
+  const [disputes, total] = await Promise.all([
+    Dispute.find(filters)
+      .populate(disputePopulateFields)
+      .sort({ createdAt: -1 })
+      .skip((resolvedPage - 1) * resolvedLimit)
+      .limit(resolvedLimit),
+    Dispute.countDocuments(filters),
+  ]);
+
+  res.status(200).json(
+    new ApiResponse(
+      200,
+      {
+        items: disputes.map(sanitizeDispute),
+        pagination: {
+          page: resolvedPage,
+          limit: resolvedLimit,
+          total,
+          totalPages: Math.ceil(total / resolvedLimit) || 1,
+        },
+        filters: {
+          status: status || "",
+          openedByRole: openedByRole || "",
+          taskId: taskId || "",
+        },
+      },
+      "Disputes fetched successfully",
+    ),
+  );
+});
+
+const updateDisputeStatus = asyncHandler(async (req, res) => {
+  const { disputeId } = req.params;
+  const { status, resolutionNote } = req.body;
+
+  ensureValidObjectId(disputeId, "dispute id");
+
+  if (!allowedDisputeStatuses.includes(status) || status === "open") {
+    throw new ApiError(400, "Invalid dispute status provided");
+  }
+
+  const dispute = await Dispute.findById(disputeId).populate(disputePopulateFields);
+  if (!dispute) {
+    throw new ApiError(404, "Dispute not found");
+  }
+
+  dispute.status = status;
+  dispute.reviewedBy = req.user._id;
+  dispute.reviewedAt = new Date();
+  dispute.resolutionNote = resolutionNote?.trim() || "";
+
+  await dispute.save();
+  await dispute.populate(disputePopulateFields);
+
+  res.status(200).json(
+    new ApiResponse(200, sanitizeDispute(dispute), "Dispute status updated successfully"),
+  );
+});
+
+export {
+  createDispute,
+  getDisputeById,
+  listAllDisputes,
+  listMyDisputes,
+  updateDisputeStatus,
+};

--- a/backend/src/docs/swagger.js
+++ b/backend/src/docs/swagger.js
@@ -170,6 +170,54 @@ const reportSchema = {
   },
 };
 
+const disputeSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string", example: "67ca72d999ea40f2abc77777" },
+    task: { $ref: "#/components/schemas/Task" },
+    openedBy: { $ref: "#/components/schemas/User" },
+    openedByRole: {
+      type: "string",
+      enum: ["requester", "runner"],
+      example: "requester",
+    },
+    reason: { type: "string", example: "Task marked complete with missing items" },
+    details: {
+      type: "string",
+      example: "The runner marked the task as completed but the delivered package was incomplete.",
+    },
+    evidence: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          type: { type: "string", example: "image" },
+          label: { type: "string", example: "Delivery photo" },
+          url: { type: "string", example: "https://example.com/evidence.png" },
+          note: { type: "string", example: "Photo captured after delivery" },
+        },
+      },
+    },
+    status: {
+      type: "string",
+      enum: ["open", "under_review", "resolved", "dismissed"],
+      example: "open",
+    },
+    resolutionNote: {
+      type: "string",
+      example: "Reviewed with both parties and resolved in favor of the requester.",
+    },
+    reviewedBy: {
+      anyOf: [{ $ref: "#/components/schemas/User" }, { type: "null" }],
+    },
+    reviewedAt: {
+      anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+    },
+    createdAt: { type: "string", format: "date-time" },
+    updatedAt: { type: "string", format: "date-time" },
+  },
+};
+
 const apiResponse = (dataSchema, messageExample = "Success") => ({
   type: "object",
   properties: {
@@ -199,6 +247,7 @@ const swaggerDocument = {
     { name: "Auth", description: "Authentication and session routes" },
     { name: "Profile", description: "Protected profile routes" },
     { name: "Tasks", description: "Protected task lifecycle routes" },
+    { name: "Disputes", description: "Task dispute creation and review routes" },
     { name: "Wallet", description: "Wallet balance and ledger routes" },
     { name: "Admin", description: "Admin moderation routes" },
   ],
@@ -210,6 +259,7 @@ const swaggerDocument = {
       WalletTransaction: walletTransactionSchema,
       WalletBalance: walletBalanceSchema,
       Report: reportSchema,
+      Dispute: disputeSchema,
       RegisterRequest: {
         type: "object",
         required: ["fullName", "email", "password"],
@@ -297,6 +347,8 @@ const swaggerDocument = {
         required: ["isActive"],
         properties: {
           isActive: { type: "boolean", example: false },
+        },
+      },
       CreateTaskRequest: {
         type: "object",
         required: ["title", "description", "pickupLocation", "dropoffLocation"],
@@ -308,9 +360,6 @@ const swaggerDocument = {
           },
           pickupLocation: { type: "string", example: "Academic Block A" },
           dropoffLocation: { type: "string", example: "Hostel 3 Reception" },
-          reward: { type: "number", example: 80 },
-        },
-      },
           campus: { type: "string", example: "VIT Bhopal" },
           transportMode: {
             type: "string",
@@ -429,6 +478,48 @@ const swaggerDocument = {
           },
         },
       },
+      CreateDisputeRequest: {
+        type: "object",
+        required: ["taskId", "reason"],
+        properties: {
+          taskId: { type: "string", example: "67ca72d999ea40f2abc98765" },
+          reason: {
+            type: "string",
+            example: "Task marked complete with missing items",
+          },
+          details: {
+            type: "string",
+            example: "Some items were not delivered even though the task was closed as completed.",
+          },
+          evidence: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                type: { type: "string", example: "image" },
+                label: { type: "string", example: "Damaged parcel photo" },
+                url: { type: "string", example: "https://example.com/dispute-proof.png" },
+                note: { type: "string", example: "Photo taken immediately after handoff" },
+              },
+            },
+          },
+        },
+      },
+      UpdateDisputeStatusRequest: {
+        type: "object",
+        required: ["status"],
+        properties: {
+          status: {
+            type: "string",
+            enum: ["under_review", "resolved", "dismissed"],
+            example: "resolved",
+          },
+          resolutionNote: {
+            type: "string",
+            example: "Reviewed the task logs and evidence, then resolved in favor of the requester.",
+          },
+        },
+      },
       AuthResponse: apiResponse(
         {
           type: "object",
@@ -535,6 +626,39 @@ const swaggerDocument = {
           },
         },
         "Reported issues fetched successfully",
+      ),
+      DisputeResponse: apiResponse(
+        { $ref: "#/components/schemas/Dispute" },
+        "Dispute fetched successfully",
+      ),
+      DisputeListResponse: apiResponse(
+        {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: { $ref: "#/components/schemas/Dispute" },
+            },
+            pagination: {
+              type: "object",
+              properties: {
+                page: { type: "integer", example: 1 },
+                limit: { type: "integer", example: 20 },
+                total: { type: "integer", example: 2 },
+                totalPages: { type: "integer", example: 1 },
+              },
+            },
+            filters: {
+              type: "object",
+              properties: {
+                status: { type: "string", example: "open" },
+                openedByRole: { type: "string", example: "runner" },
+                taskId: { type: "string", example: "67ca72d999ea40f2abc98765" },
+              },
+            },
+          },
+        },
+        "Disputes fetched successfully",
       ),
     },
   },
@@ -1104,6 +1228,183 @@ const swaggerDocument = {
         responses: {
           200: {
             description: "Task cancelled successfully",
+          },
+        },
+      },
+    },
+    "/api/v1/disputes/mine": {
+      get: {
+        tags: ["Disputes"],
+        summary: "List disputes opened by the current user",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            in: "query",
+            name: "status",
+            schema: {
+              type: "string",
+              enum: ["open", "under_review", "resolved", "dismissed"],
+            },
+          },
+          {
+            in: "query",
+            name: "page",
+            schema: { type: "integer", example: 1 },
+          },
+          {
+            in: "query",
+            name: "limit",
+            schema: { type: "integer", example: 20 },
+          },
+        ],
+        responses: {
+          200: {
+            description: "Disputes fetched successfully",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/DisputeListResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/disputes": {
+      get: {
+        tags: ["Disputes"],
+        summary: "List all disputes for admin review",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            in: "query",
+            name: "status",
+            schema: {
+              type: "string",
+              enum: ["open", "under_review", "resolved", "dismissed"],
+            },
+          },
+          {
+            in: "query",
+            name: "openedByRole",
+            schema: {
+              type: "string",
+              enum: ["requester", "runner"],
+            },
+          },
+          {
+            in: "query",
+            name: "taskId",
+            schema: { type: "string" },
+          },
+          {
+            in: "query",
+            name: "page",
+            schema: { type: "integer", example: 1 },
+          },
+          {
+            in: "query",
+            name: "limit",
+            schema: { type: "integer", example: 20 },
+          },
+        ],
+        responses: {
+          200: {
+            description: "Disputes fetched successfully",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/DisputeListResponse" },
+              },
+            },
+          },
+          403: {
+            description: "Admin only route",
+          },
+        },
+      },
+      post: {
+        tags: ["Disputes"],
+        summary: "Open a dispute on a completed or cancelled task",
+        security: [{ bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateDisputeRequest" },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: "Dispute opened successfully",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/DisputeResponse" },
+              },
+            },
+          },
+          409: {
+            description: "Task is not eligible for dispute or a duplicate dispute already exists",
+          },
+        },
+      },
+    },
+    "/api/v1/disputes/{disputeId}": {
+      get: {
+        tags: ["Disputes"],
+        summary: "Get dispute details",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            in: "path",
+            name: "disputeId",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          200: {
+            description: "Dispute fetched successfully",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/DisputeResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/disputes/{disputeId}/status": {
+      patch: {
+        tags: ["Disputes"],
+        summary: "Update dispute status as admin",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            in: "path",
+            name: "disputeId",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UpdateDisputeStatusRequest" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Dispute status updated successfully",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/DisputeResponse" },
+              },
+            },
+          },
+          403: {
+            description: "Admin only route",
           },
         },
       },

--- a/backend/src/models/dispute.model.js
+++ b/backend/src/models/dispute.model.js
@@ -1,0 +1,100 @@
+import mongoose from "mongoose";
+
+const allowedDisputeStatuses = ["open", "under_review", "resolved", "dismissed"];
+const allowedDisputeOpenedByRoles = ["requester", "runner"];
+
+const disputeEvidenceSchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      trim: true,
+      default: "link",
+    },
+    label: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    url: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    note: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+  },
+  {
+    _id: false,
+  },
+);
+
+const disputeSchema = new mongoose.Schema(
+  {
+    task: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Task",
+      required: true,
+      index: true,
+    },
+    openedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    openedByRole: {
+      type: String,
+      enum: allowedDisputeOpenedByRoles,
+      required: true,
+    },
+    reason: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    details: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    evidence: {
+      type: [disputeEvidenceSchema],
+      default: [],
+    },
+    status: {
+      type: String,
+      enum: allowedDisputeStatuses,
+      default: "open",
+      index: true,
+    },
+    resolutionNote: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    reviewedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
+    reviewedAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+disputeSchema.index({ status: 1, createdAt: -1 });
+disputeSchema.index({ task: 1, status: 1, createdAt: -1 });
+disputeSchema.index({ openedBy: 1, createdAt: -1 });
+disputeSchema.index({ task: 1, openedBy: 1 }, { unique: true });
+
+const Dispute = mongoose.model("Dispute", disputeSchema);
+
+export { Dispute, allowedDisputeOpenedByRoles, allowedDisputeStatuses };

--- a/backend/src/routes/dispute.routes.js
+++ b/backend/src/routes/dispute.routes.js
@@ -1,0 +1,22 @@
+import { Router } from "express";
+
+import {
+  createDispute,
+  getDisputeById,
+  listAllDisputes,
+  listMyDisputes,
+  updateDisputeStatus,
+} from "../controllers/dispute.controller.js";
+import { authorizeRoles, verifyJWT } from "../middlewares/auth.middleware.js";
+
+const router = Router();
+
+router.use(verifyJWT);
+
+router.get("/mine", listMyDisputes);
+router.get("/", authorizeRoles("admin"), listAllDisputes);
+router.get("/:disputeId", getDisputeById);
+router.post("/", authorizeRoles("requester", "runner"), createDispute);
+router.patch("/:disputeId/status", authorizeRoles("admin"), updateDisputeStatus);
+
+export default router;

--- a/backend/test/task-dispute.test.js
+++ b/backend/test/task-dispute.test.js
@@ -1,0 +1,231 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+process.env.ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET || "test-access-secret";
+process.env.REFRESH_TOKEN_SECRET =
+  process.env.REFRESH_TOKEN_SECRET || "test-refresh-secret";
+process.env.CORS_ORIGIN = process.env.CORS_ORIGIN || "http://localhost:3000";
+process.env.MONGODB_URI = process.env.MONGODB_URI || "mongodb://127.0.0.1:27017";
+
+const [{ app }, { Task }, { User }, { Dispute }] = await Promise.all([
+  import("../src/app.js"),
+  import("../src/models/task.model.js"),
+  import("../src/models/user.model.js"),
+  import("../src/models/dispute.model.js"),
+]);
+
+const createAccessToken = (user) =>
+  jwt.sign(
+    {
+      _id: user._id.toString(),
+      email: user.email,
+      role: user.role,
+    },
+    process.env.ACCESS_TOKEN_SECRET,
+    {
+      expiresIn: "1h",
+    },
+  );
+
+const createUser = async ({ fullName, email, role }) => {
+  return User.create({
+    fullName,
+    email,
+    password: "Password123!",
+    role,
+    isVerified: true,
+    isActive: true,
+    phoneNumber: "",
+    campusId: "",
+    campusName: "",
+  });
+};
+
+describe("task disputes", () => {
+  let mongoServer;
+
+  before(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri(), {
+      dbName: "campus-runner-dispute-tests",
+    });
+  });
+
+  after(async () => {
+    await mongoose.disconnect();
+
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
+  beforeEach(async () => {
+    await Promise.all([User.deleteMany({}), Task.deleteMany({}), Dispute.deleteMany({})]);
+  });
+
+  it("allows a task participant to open a dispute and lets an admin resolve it", async () => {
+    const requester = await createUser({
+      fullName: "Requester",
+      email: "dispute-requester@example.com",
+      role: "requester",
+    });
+    const runner = await createUser({
+      fullName: "Runner",
+      email: "dispute-runner@example.com",
+      role: "runner",
+    });
+    const admin = await createUser({
+      fullName: "Admin",
+      email: "dispute-admin@example.com",
+      role: "admin",
+    });
+
+    const task = await Task.create({
+      title: "Collect notes",
+      description: "Pick up printed notes and deliver to hostel",
+      pickupLocation: "Library",
+      dropoffLocation: "Hostel 2",
+      reward: 50,
+      requestedBy: requester._id,
+      assignedRunner: runner._id,
+      status: "completed",
+      acceptedAt: new Date("2026-03-08T10:00:00.000Z"),
+      startedAt: new Date("2026-03-08T10:10:00.000Z"),
+      completedAt: new Date("2026-03-08T10:40:00.000Z"),
+    });
+
+    const createResponse = await request(app)
+      .post("/api/v1/disputes")
+      .set("Authorization", `Bearer ${createAccessToken(requester)}`)
+      .send({
+        taskId: task._id.toString(),
+        reason: "Task outcome mismatch",
+        details: "The delivery was marked complete but items were missing.",
+        evidence: [
+          {
+            type: "image",
+            label: "Photo proof",
+            url: "https://example.com/proof.png",
+            note: "Photo taken after delivery",
+          },
+        ],
+      });
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(createResponse.body.success, true);
+    assert.equal(createResponse.body.data.status, "open");
+    assert.equal(createResponse.body.data.openedByRole, "requester");
+    assert.equal(createResponse.body.data.evidence.length, 1);
+
+    const adminListResponse = await request(app)
+      .get("/api/v1/disputes")
+      .set("Authorization", `Bearer ${createAccessToken(admin)}`);
+
+    assert.equal(adminListResponse.status, 200);
+    assert.equal(adminListResponse.body.data.items.length, 1);
+
+    const disputeId = createResponse.body.data.id;
+    const resolveResponse = await request(app)
+      .patch(`/api/v1/disputes/${disputeId}/status`)
+      .set("Authorization", `Bearer ${createAccessToken(admin)}`)
+      .send({
+        status: "resolved",
+        resolutionNote: "Reviewed the evidence and marked the dispute resolved.",
+      });
+
+    assert.equal(resolveResponse.status, 200);
+    assert.equal(resolveResponse.body.data.status, "resolved");
+    assert.ok(resolveResponse.body.data.reviewedAt);
+    assert.equal(resolveResponse.body.data.reviewedBy.id, admin._id.toString());
+  });
+
+  it("rejects disputes from non-participants, disallows in-progress disputes, and blocks duplicates", async () => {
+    const requester = await createUser({
+      fullName: "Requester Two",
+      email: "dispute-requester-two@example.com",
+      role: "requester",
+    });
+    const runner = await createUser({
+      fullName: "Runner Two",
+      email: "dispute-runner-two@example.com",
+      role: "runner",
+    });
+    const outsider = await createUser({
+      fullName: "Runner Outsider",
+      email: "dispute-outsider@example.com",
+      role: "runner",
+    });
+
+    const inProgressTask = await Task.create({
+      title: "In progress task",
+      description: "This should not allow disputes yet",
+      pickupLocation: "Cafe",
+      dropoffLocation: "Lab",
+      reward: 30,
+      requestedBy: requester._id,
+      assignedRunner: runner._id,
+      status: "in_progress",
+      acceptedAt: new Date("2026-03-08T09:00:00.000Z"),
+      startedAt: new Date("2026-03-08T09:15:00.000Z"),
+    });
+
+    const earlyDisputeResponse = await request(app)
+      .post("/api/v1/disputes")
+      .set("Authorization", `Bearer ${createAccessToken(runner)}`)
+      .send({
+        taskId: inProgressTask._id.toString(),
+        reason: "Too early",
+      });
+
+    assert.equal(earlyDisputeResponse.status, 409);
+
+    const cancelledTask = await Task.create({
+      title: "Cancelled task",
+      description: "Task later cancelled",
+      pickupLocation: "Gate 1",
+      dropoffLocation: "Block D",
+      reward: 60,
+      requestedBy: requester._id,
+      assignedRunner: runner._id,
+      status: "cancelled",
+      cancelledAt: new Date("2026-03-08T11:00:00.000Z"),
+      cancellationReason: "Requester cancelled",
+    });
+
+    const outsiderDisputeResponse = await request(app)
+      .post("/api/v1/disputes")
+      .set("Authorization", `Bearer ${createAccessToken(outsider)}`)
+      .send({
+        taskId: cancelledTask._id.toString(),
+        reason: "I was not involved",
+      });
+
+    assert.equal(outsiderDisputeResponse.status, 403);
+
+    const firstRunnerDispute = await request(app)
+      .post("/api/v1/disputes")
+      .set("Authorization", `Bearer ${createAccessToken(runner)}`)
+      .send({
+        taskId: cancelledTask._id.toString(),
+        reason: "Cancellation affected payout",
+      });
+
+    assert.equal(firstRunnerDispute.status, 201);
+
+    const duplicateDispute = await request(app)
+      .post("/api/v1/disputes")
+      .set("Authorization", `Bearer ${createAccessToken(runner)}`)
+      .send({
+        taskId: cancelledTask._id.toString(),
+        reason: "Trying to open again",
+      });
+
+    assert.equal(duplicateDispute.status, 409);
+  });
+});


### PR DESCRIPTION
#91 solved 


<img width="1900" height="386" alt="image" src="https://github.com/user-attachments/assets/a86b2599-28ea-40f3-8ef2-4ad9765c0c64" />
<img width="1598" height="866" alt="image" src="https://github.com/user-attachments/assets/487f4c8b-2f7c-491b-8f1f-862776cad93a" />
<img width="1897" height="956" alt="image" src="https://github.com/user-attachments/assets/e3abdec7-7351-43e7-a737-1b428cb23b5a" />
<img width="1616" height="960" alt="image" src="https://github.com/user-attachments/assets/d87c9a72-bc6f-4d1c-a0d6-9d25830b5004" />


This PR adds a backend-only Task Dispute API that allows requesters and assigned runners to open disputes on completed or cancelled tasks, attach dispute reasons and evidence metadata, and track dispute records through a dedicated resource instead of mixing them into generic moderation flows. It introduces protected dispute endpoints for creating, viewing, and listing disputes, along with admin-only endpoints to review and resolve them, while enforcing task-participant access control, preventing disputes on invalid task states, and blocking duplicate dispute creation by the same user for the same task. The changes also extend Swagger documentation for the new dispute routes and add integration tests covering dispute creation, admin resolution, duplicate prevention, and access restrictions to validate the backend flow end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dispute system: Users can now open disputes for completed or cancelled tasks, submit supporting evidence, and track status progression through open, under review, resolved, and dismissed stages.
  * Admin controls: Administrators can view all disputes, filter by status or task, and update dispute resolutions with notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->