### PR TITLE
protected requester-only task history endpoint to the backend

### DIFF
--- a/backend/src/controllers/task.controller.js
+++ b/backend/src/controllers/task.controller.js
@@ -132,6 +132,32 @@ const decodeCursor = (cursor) => {
   }
 };
 
+const parseDateFilter = (value, fieldName, boundary) => {
+  if (!value) {
+    return null;
+  }
+
+  const normalizedValue = String(value).trim();
+  if (!normalizedValue) {
+    return null;
+  }
+
+  const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(normalizedValue);
+  const parsedDate = isDateOnly
+    ? new Date(`${normalizedValue}T00:00:00.000Z`)
+    : new Date(normalizedValue);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new ApiError(400, `Invalid ${fieldName} provided`);
+  }
+
+  if (isDateOnly && boundary === "end") {
+    parsedDate.setUTCHours(23, 59, 59, 999);
+  }
+
+  return parsedDate;
+};
+
 const resolveTaskFeedQuery = (query, overrides = {}) => {
   const {
     status,
@@ -141,6 +167,8 @@ const resolveTaskFeedQuery = (query, overrides = {}) => {
     requestedBy,
     assignedRunner,
     archived,
+    fromDate,
+    toDate,
     page = 1,
     limit = 20,
     sort = "desc",
@@ -151,6 +179,8 @@ const resolveTaskFeedQuery = (query, overrides = {}) => {
   const resolvedStatus = overrides.status ?? status;
   const resolvedCampus = overrides.campus ?? campus;
   const resolvedTransportMode = overrides.transportMode ?? transportMode;
+  const resolvedRequestedBy = overrides.requestedBy ?? requestedBy;
+  const resolvedAssignedRunner = overrides.assignedRunner ?? assignedRunner;
   const resolvedArchived =
     overrides.isArchived ??
     (archived === undefined ? false : String(archived).toLowerCase() === "true");
@@ -177,14 +207,14 @@ const resolveTaskFeedQuery = (query, overrides = {}) => {
     conditions.push({ transportMode: resolvedTransportMode });
   }
 
-  if (requestedBy) {
-    ensureValidTaskId(requestedBy);
-    conditions.push({ requestedBy });
+  if (resolvedRequestedBy) {
+    ensureValidTaskId(resolvedRequestedBy);
+    conditions.push({ requestedBy: resolvedRequestedBy });
   }
 
-  if (assignedRunner) {
-    ensureValidTaskId(assignedRunner);
-    conditions.push({ assignedRunner });
+  if (resolvedAssignedRunner) {
+    ensureValidTaskId(resolvedAssignedRunner);
+    conditions.push({ assignedRunner: resolvedAssignedRunner });
   }
 
   if (search?.trim()) {
@@ -198,6 +228,27 @@ const resolveTaskFeedQuery = (query, overrides = {}) => {
         { campus: pattern },
       ],
     });
+  }
+
+  const resolvedFromDate = parseDateFilter(overrides.fromDate ?? fromDate, "fromDate", "start");
+  const resolvedToDate = parseDateFilter(overrides.toDate ?? toDate, "toDate", "end");
+
+  if (resolvedFromDate && resolvedToDate && resolvedFromDate > resolvedToDate) {
+    throw new ApiError(400, "fromDate cannot be later than toDate");
+  }
+
+  if (resolvedFromDate || resolvedToDate) {
+    const createdAtFilter = {};
+
+    if (resolvedFromDate) {
+      createdAtFilter.$gte = resolvedFromDate;
+    }
+
+    if (resolvedToDate) {
+      createdAtFilter.$lte = resolvedToDate;
+    }
+
+    conditions.push({ createdAt: createdAtFilter });
   }
 
   const resolvedSort = String(sort).toLowerCase() === "asc" ? 1 : -1;
@@ -425,6 +476,8 @@ const listTasks = asyncHandler(async (req, res) => {
           campus: req.query.campus || "",
           status: req.query.status || "",
           transportMode: req.query.transportMode || "",
+          fromDate: req.query.fromDate || "",
+          toDate: req.query.toDate || "",
           archived:
             req.query.archived === undefined
               ? false
@@ -432,6 +485,33 @@ const listTasks = asyncHandler(async (req, res) => {
         },
       },
       "Tasks fetched successfully",
+    ),
+  );
+});
+
+const listRequesterTaskHistory = asyncHandler(async (req, res) => {
+  const { items, pagination } = await fetchTaskFeed(req.query, {
+    requestedBy: req.user._id,
+  });
+
+  res.status(200).json(
+    new ApiResponse(
+      200,
+      {
+        items: items.map(sanitizeTask),
+        pagination,
+        filters: {
+          search: req.query.search || "",
+          status: req.query.status || "",
+          fromDate: req.query.fromDate || "",
+          toDate: req.query.toDate || "",
+          archived:
+            req.query.archived === undefined
+              ? false
+              : String(req.query.archived).toLowerCase() === "true",
+        },
+      },
+      "Requester task history fetched successfully",
     ),
   );
 });
@@ -564,7 +644,7 @@ const cancelTask = asyncHandler(async (req, res) => {
 const listProtectedTaskActions = asyncHandler(async (req, res) => {
   const allowedActions =
     req.user.role === "requester"
-      ? ["create-task", "list-open-tasks", "cancel-own-task"]
+      ? ["create-task", "list-open-tasks", "list-own-task-history", "cancel-own-task"]
       : req.user.role === "runner"
         ? [
             "list-open-tasks",
@@ -605,6 +685,7 @@ export {
   completeTask,
   createTask,
   getTaskById,
+  listRequesterTaskHistory,
   listTasks,
   listOpenTasks,
   listProtectedTaskActions,

--- a/backend/src/docs/swagger.js
+++ b/backend/src/docs/swagger.js
@@ -348,6 +348,9 @@ const swaggerDocument = {
                 campus: { type: "string", example: "VIT Bhopal" },
                 status: { type: "string", example: "open" },
                 transportMode: { type: "string", example: "bike" },
+                fromDate: { type: "string", example: "2026-03-01" },
+                toDate: { type: "string", example: "2026-03-08" },
+                archived: { type: "boolean", example: false },
               },
             },
           },
@@ -856,6 +859,76 @@ const swaggerDocument = {
         },
       },
     },
+    "/api/v1/tasks/history": {
+      get: {
+        tags: ["Tasks"],
+        summary: "Get requester task history",
+        description:
+          "Requester-only route that returns the authenticated requester's own tasks with pagination, status filters, created-date filters, and search by title or location fields.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            in: "query",
+            name: "search",
+            schema: { type: "string", example: "library" },
+          },
+          {
+            in: "query",
+            name: "status",
+            schema: {
+              type: "string",
+              enum: ["open", "accepted", "in_progress", "completed", "cancelled"],
+            },
+          },
+          {
+            in: "query",
+            name: "fromDate",
+            schema: { type: "string", example: "2026-03-01" },
+            description: "Inclusive lower bound for task createdAt. Supports ISO timestamps or YYYY-MM-DD.",
+          },
+          {
+            in: "query",
+            name: "toDate",
+            schema: { type: "string", example: "2026-03-08" },
+            description: "Inclusive upper bound for task createdAt. Supports ISO timestamps or YYYY-MM-DD.",
+          },
+          {
+            in: "query",
+            name: "sort",
+            schema: { type: "string", enum: ["asc", "desc"], example: "desc" },
+          },
+          {
+            in: "query",
+            name: "page",
+            schema: { type: "integer", example: 1 },
+          },
+          {
+            in: "query",
+            name: "limit",
+            schema: { type: "integer", example: 20 },
+          },
+          {
+            in: "query",
+            name: "cursor",
+            schema: { type: "string" },
+            description: "Optional cursor token for cursor-based pagination; when provided, page is ignored.",
+          },
+        ],
+        responses: {
+          200: {
+            description: "Requester task history fetched successfully",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TaskFeedResponse" },
+              },
+            },
+          },
+          403: {
+            description: "Requester role required",
+          },
+        },
+      },
+    },
     "/api/v1/tasks/open": {
       get: {
         tags: ["Tasks"],
@@ -926,6 +999,16 @@ const swaggerDocument = {
               type: "string",
               enum: ["walk", "bike", "car", "public_transport", "other"],
             },
+          },
+          {
+            in: "query",
+            name: "fromDate",
+            schema: { type: "string", example: "2026-03-01" },
+          },
+          {
+            in: "query",
+            name: "toDate",
+            schema: { type: "string", example: "2026-03-08" },
           },
           {
             in: "query",

--- a/backend/src/routes/task.routes.js
+++ b/backend/src/routes/task.routes.js
@@ -6,6 +6,7 @@ import {
   completeTask,
   createTask,
   getTaskById,
+  listRequesterTaskHistory,
   listTasks,
   listOpenTasks,
   listProtectedTaskActions,
@@ -18,6 +19,7 @@ const router = Router();
 router.use(verifyJWT);
 
 router.get("/protected-actions", listProtectedTaskActions);
+router.get("/history", authorizeRoles("requester"), listRequesterTaskHistory);
 router.get("/", listTasks);
 router.get("/open", listOpenTasks);
 router.get("/:taskId", getTaskById);

--- a/backend/test/requester-task-history.test.js
+++ b/backend/test/requester-task-history.test.js
@@ -1,0 +1,174 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+process.env.ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET || "test-access-secret";
+process.env.REFRESH_TOKEN_SECRET =
+  process.env.REFRESH_TOKEN_SECRET || "test-refresh-secret";
+process.env.CORS_ORIGIN = process.env.CORS_ORIGIN || "http://localhost:3000";
+process.env.MONGODB_URI = process.env.MONGODB_URI || "mongodb://127.0.0.1:27017";
+
+const [{ app }, { Task }, { User }] = await Promise.all([
+  import("../src/app.js"),
+  import("../src/models/task.model.js"),
+  import("../src/models/user.model.js"),
+]);
+
+const createAccessToken = (user) =>
+  jwt.sign(
+    {
+      _id: user._id.toString(),
+      email: user.email,
+      role: user.role,
+    },
+    process.env.ACCESS_TOKEN_SECRET,
+    {
+      expiresIn: "1h",
+    },
+  );
+
+const createUser = async ({ fullName, email, role }) => {
+  return User.create({
+    fullName,
+    email,
+    password: "Password123!",
+    role,
+    isVerified: true,
+    isActive: true,
+    phoneNumber: "",
+    campusId: "main-campus",
+    campusName: "Main Campus",
+  });
+};
+
+describe("requester task history", () => {
+  let mongoServer;
+
+  before(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri(), {
+      dbName: "campus-runner-requester-history-tests",
+    });
+  });
+
+  after(async () => {
+    await mongoose.disconnect();
+
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
+  beforeEach(async () => {
+    await Promise.all([User.deleteMany({}), Task.deleteMany({})]);
+  });
+
+  it("returns only the current requester's tasks with pagination and filters", async () => {
+    const [requesterOne, requesterTwo, runner] = await Promise.all([
+      createUser({
+        fullName: "Requester One",
+        email: "requester-one@example.com",
+        role: "requester",
+      }),
+      createUser({
+        fullName: "Requester Two",
+        email: "requester-two@example.com",
+        role: "requester",
+      }),
+      createUser({
+        fullName: "Runner One",
+        email: "runner-one@example.com",
+        role: "runner",
+      }),
+    ]);
+
+    await Task.create([
+      {
+        title: "Library pickup run",
+        description: "Collect books from library",
+        pickupLocation: "Central Library",
+        dropoffLocation: "Hostel A",
+        reward: 100,
+        requestedBy: requesterOne._id,
+        assignedRunner: runner._id,
+        status: "completed",
+        createdAt: new Date("2026-03-02T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-02T11:00:00.000Z"),
+      },
+      {
+        title: "North gate parcel",
+        description: "Pick parcel from gate",
+        pickupLocation: "North Gate",
+        dropoffLocation: "Hostel B",
+        reward: 50,
+        requestedBy: requesterOne._id,
+        status: "cancelled",
+        createdAt: new Date("2026-03-05T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-05T13:00:00.000Z"),
+      },
+      {
+        title: "Cafeteria token pickup",
+        description: "Pick up meal token",
+        pickupLocation: "Cafeteria",
+        dropoffLocation: "Academic Block",
+        reward: 30,
+        requestedBy: requesterOne._id,
+        status: "open",
+        createdAt: new Date("2026-02-20T09:00:00.000Z"),
+        updatedAt: new Date("2026-02-20T09:30:00.000Z"),
+      },
+      {
+        title: "Library documents",
+        description: "Another requester task",
+        pickupLocation: "Central Library",
+        dropoffLocation: "Hostel C",
+        reward: 40,
+        requestedBy: requesterTwo._id,
+        status: "completed",
+        createdAt: new Date("2026-03-04T08:00:00.000Z"),
+        updatedAt: new Date("2026-03-04T09:00:00.000Z"),
+      },
+    ]);
+
+    const authHeader = {
+      Authorization: `Bearer ${createAccessToken(requesterOne)}`,
+    };
+
+    const paginatedResponse = await request(app)
+      .get("/api/v1/tasks/history?page=1&limit=2&sort=desc")
+      .set(authHeader);
+
+    assert.equal(paginatedResponse.status, 200);
+    assert.equal(paginatedResponse.body.success, true);
+    assert.equal(paginatedResponse.body.data.items.length, 2);
+    assert.equal(paginatedResponse.body.data.pagination.total, 3);
+    assert.equal(paginatedResponse.body.data.pagination.totalPages, 2);
+    assert.ok(
+      paginatedResponse.body.data.items.every(
+        (task) => task.requestedBy.id === requesterOne._id.toString(),
+      ),
+    );
+
+    const filteredResponse = await request(app)
+      .get(
+        "/api/v1/tasks/history?status=completed&search=library&fromDate=2026-03-01&toDate=2026-03-08",
+      )
+      .set(authHeader);
+
+    assert.equal(filteredResponse.status, 200);
+    assert.equal(filteredResponse.body.success, true);
+    assert.equal(filteredResponse.body.data.items.length, 1);
+    assert.equal(filteredResponse.body.data.items[0].title, "Library pickup run");
+    assert.equal(filteredResponse.body.data.items[0].requestedBy.id, requesterOne._id.toString());
+    assert.equal(filteredResponse.body.data.items[0].status, "completed");
+    assert.equal(filteredResponse.body.data.filters.status, "completed");
+    assert.equal(filteredResponse.body.data.filters.search, "library");
+    assert.equal(filteredResponse.body.data.filters.fromDate, "2026-03-01");
+    assert.equal(filteredResponse.body.data.filters.toDate, "2026-03-08");
+  });
+});


### PR DESCRIPTION
#94 solved 

<img width="1600" height="952" alt="image" src="https://github.com/user-attachments/assets/1097c862-b3ff-49fe-9800-26a39846b69f" />


This PR adds a protected requester-only task history endpoint to the backend, allowing authenticated requesters to fetch only their own tasks with pagination, status-based filtering, date-range filtering on task creation time, and search across title and location fields. The implementation reuses the existing shared task feed query pipeline to avoid duplicating filtering and pagination logic, while fixing the underlying override handling so route-level requester scoping is enforced correctly. It also updates Swagger documentation to describe the new history route and date-filter support, and adds an integration test covering requester ownership, filters, and pagination to verify the end-to-end behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date range filtering (fromDate/toDate) to task listings and open tasks endpoints
  * Introduced requester task history endpoint with pagination, status filtering, and date range search capabilities
  * Extended requester permissions to access own task history

* **Documentation**
  * Updated API documentation for date filters and new history endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->