### PR TITLE
cooldown enforcement api

### DIFF
--- a/backend/src/controllers/admin.controller.js
+++ b/backend/src/controllers/admin.controller.js
@@ -10,11 +10,13 @@ import { Report, allowedReportEntityTypes, allowedReportStatuses } from "../mode
 import { Task } from "../models/task.model.js";
 import { User } from "../models/user.model.js";
 import { sanitizeUser as sanitizeProfileUser } from "./profile.controller.js";
+import { allowedCooldownActions } from "../models/user.model.js";
 import { validateCampusScopesInput } from "../utils/campusScope.js";
 import {
   buildRunnerMetricsMap,
   buildRunnerPerformanceEntry,
 } from "../services/runnerPerformance.service.js";
+import { applyUserCooldown, isCooldownActive } from "../services/cooldown.service.js";
 import { WalletTransaction } from "../models/walletTransaction.model.js";
 import { ApiError } from "../utils/ApiError.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
@@ -205,6 +207,27 @@ const sanitizeFraudFlag = (flag) => ({
   resolutionNote: flag.resolutionNote,
   createdAt: flag.createdAt,
   updatedAt: flag.updatedAt,
+});
+
+const sanitizeCooldown = (cooldown) => ({
+  id: cooldown._id,
+  action: cooldown.action,
+  reason: cooldown.reason,
+  sourceType: cooldown.sourceType,
+  startsAt: cooldown.startsAt,
+  endsAt: cooldown.endsAt,
+  isActive: isCooldownActive(cooldown),
+  triggeredBy:
+    cooldown.triggeredBy && cooldown.triggeredBy._id
+      ? sanitizeUser(cooldown.triggeredBy)
+      : cooldown.triggeredBy || null,
+  clearedAt: cooldown.clearedAt,
+  clearedBy:
+    cooldown.clearedBy && cooldown.clearedBy._id
+      ? sanitizeUser(cooldown.clearedBy)
+      : cooldown.clearedBy || null,
+  clearReason: cooldown.clearReason,
+  metadata: cooldown.metadata || {},
 });
 
 const ensureValidObjectId = (value, fieldName) => {
@@ -834,6 +857,153 @@ const updateUserCampusScopes = asyncHandler(async (req, res) => {
   );
 });
 
+const listUserCooldowns = asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+
+  ensureValidObjectId(userId, "user id");
+
+  const user = await User.findById(userId).populate([
+    {
+      path: "cooldowns.triggeredBy",
+      select: "fullName email phoneNumber role isVerified isActive",
+    },
+    {
+      path: "cooldowns.clearedBy",
+      select: "fullName email phoneNumber role isVerified isActive",
+    },
+  ]);
+
+  if (!user) {
+    throw new ApiError(404, "User not found");
+  }
+
+  const cooldowns = [...(user.cooldowns || [])].sort((left, right) => right.startsAt - left.startsAt);
+
+  res.status(200).json(
+    new ApiResponse(
+      200,
+      {
+        user: sanitizeProfileUser(user),
+        activeCooldowns: cooldowns.filter((cooldown) => isCooldownActive(cooldown)).map(sanitizeCooldown),
+        cooldownHistory: cooldowns.map(sanitizeCooldown),
+      },
+      "User cooldowns fetched successfully",
+    ),
+  );
+});
+
+const createUserCooldown = asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  const { action, reason, durationHours } = req.body;
+
+  ensureValidObjectId(userId, "user id");
+
+  if (!allowedCooldownActions.includes(action)) {
+    throw new ApiError(400, "Invalid cooldown action provided");
+  }
+
+  const parsedDurationHours = Number(durationHours);
+  if (!Number.isFinite(parsedDurationHours) || parsedDurationHours <= 0 || parsedDurationHours > 168) {
+    throw new ApiError(400, "durationHours must be a number between 1 and 168");
+  }
+
+  const user = await User.findById(userId);
+  if (!user) {
+    throw new ApiError(404, "User not found");
+  }
+
+  const cooldown = await applyUserCooldown({
+    userId,
+    action,
+    durationHours: parsedDurationHours,
+    reason: reason?.trim() || "Manual admin cooldown applied",
+    sourceType: "admin",
+    triggeredBy: req.user._id,
+    metadata: {
+      manual: true,
+    },
+  });
+
+  await user.populate([
+    {
+      path: "cooldowns.triggeredBy",
+      select: "fullName email phoneNumber role isVerified isActive",
+    },
+    {
+      path: "cooldowns.clearedBy",
+      select: "fullName email phoneNumber role isVerified isActive",
+    },
+  ]);
+
+  const savedCooldown = user.cooldowns.id(cooldown._id);
+
+  res.status(201).json(
+    new ApiResponse(
+      201,
+      {
+        user: sanitizeProfileUser(user),
+        cooldown: sanitizeCooldown(savedCooldown),
+      },
+      "User cooldown created successfully",
+    ),
+  );
+});
+
+const clearUserCooldown = asyncHandler(async (req, res) => {
+  const { userId, cooldownId } = req.params;
+  const { clearReason } = req.body;
+
+  ensureValidObjectId(userId, "user id");
+  ensureValidObjectId(cooldownId, "cooldown id");
+
+  const user = await User.findById(userId).populate([
+    {
+      path: "cooldowns.triggeredBy",
+      select: "fullName email phoneNumber role isVerified isActive",
+    },
+    {
+      path: "cooldowns.clearedBy",
+      select: "fullName email phoneNumber role isVerified isActive",
+    },
+  ]);
+
+  if (!user) {
+    throw new ApiError(404, "User not found");
+  }
+
+  const cooldown = user.cooldowns.id(cooldownId);
+  if (!cooldown) {
+    throw new ApiError(404, "Cooldown not found");
+  }
+
+  cooldown.clearedAt = new Date();
+  cooldown.clearedBy = req.user._id;
+  cooldown.clearReason = clearReason?.trim() || "Cooldown cleared by admin";
+
+  await user.save({ validateBeforeSave: false });
+  await user.populate([
+    {
+      path: "cooldowns.triggeredBy",
+      select: "fullName email phoneNumber role isVerified isActive",
+    },
+    {
+      path: "cooldowns.clearedBy",
+      select: "fullName email phoneNumber role isVerified isActive",
+    },
+  ]);
+
+  res.status(200).json(
+    new ApiResponse(
+      200,
+      {
+        user: sanitizeProfileUser(user),
+        cooldown: sanitizeCooldown(user.cooldowns.id(cooldownId)),
+      },
+      "User cooldown cleared successfully",
+    ),
+  );
+});
+
 const listFraudFlags = asyncHandler(async (req, res) => {
   const { status, severity, flagType, page = 1, limit = 20 } = req.query;
 
@@ -926,12 +1096,15 @@ const updateFraudFlagStatus = asyncHandler(async (req, res) => {
 
 export {
   archiveTask,
+  clearUserCooldown,
+  createUserCooldown,
   getAdminAnalyticsDashboard,
   getRunnerPerformanceById,
   getRunnerPerformanceMetrics,
   getUserCampusScopes,
   listFraudFlags,
   listReportedIssues,
+  listUserCooldowns,
   suspendUser,
   updateReportStatus,
   updateFraudFlagStatus,

--- a/backend/src/middlewares/cooldown.middleware.js
+++ b/backend/src/middlewares/cooldown.middleware.js
@@ -1,0 +1,47 @@
+import { User } from "../models/user.model.js";
+import {
+  getActiveCooldownForAction,
+  getCooldownActionLabel,
+} from "../services/cooldown.service.js";
+
+const createCooldownMiddleware = ({ action, bypassRoles = ["admin"] }) => {
+  return async (req, res, next) => {
+    if (!req.user || !action) {
+      next();
+      return;
+    }
+
+    if (bypassRoles.includes(req.user.role)) {
+      next();
+      return;
+    }
+
+    const user = await User.findById(req.user._id);
+    const activeCooldown = getActiveCooldownForAction(user, action);
+
+    if (!activeCooldown) {
+      next();
+      return;
+    }
+
+    const remainingSeconds = Math.max(
+      1,
+      Math.ceil((activeCooldown.endsAt.getTime() - Date.now()) / 1000),
+    );
+
+    res.set("Retry-After", String(remainingSeconds));
+    res.status(429).json({
+      success: false,
+      message: `${getCooldownActionLabel(action)} is temporarily unavailable because this account is in cooldown.`,
+      data: {
+        action,
+        reason: activeCooldown.reason,
+        sourceType: activeCooldown.sourceType,
+        endsAt: activeCooldown.endsAt,
+        remainingSeconds,
+      },
+    });
+  };
+};
+
+export { createCooldownMiddleware };

--- a/backend/src/models/user.model.js
+++ b/backend/src/models/user.model.js
@@ -3,6 +3,87 @@ import jwt from "jsonwebtoken";
 import mongoose from "mongoose";
 
 const allowedRoles = ["requester", "runner", "admin"];
+const allowedCooldownActions = [
+  "task_creation",
+  "task_cancellation",
+  "task_acceptance",
+  "wallet_withdrawal",
+];
+const allowedCooldownSourceTypes = [
+  "admin",
+  "repeated_cancellations",
+  "wallet_abuse",
+  "unusually_fast_completion",
+  "self_dealing_pattern",
+];
+
+const campusScopeSchema = new mongoose.Schema(
+  {
+    campusId: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    campusName: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+  },
+  { _id: false },
+);
+
+const cooldownSchema = new mongoose.Schema(
+  {
+    action: {
+      type: String,
+      enum: allowedCooldownActions,
+      required: true,
+    },
+    reason: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    sourceType: {
+      type: String,
+      enum: allowedCooldownSourceTypes,
+      required: true,
+    },
+    startsAt: {
+      type: Date,
+      default: Date.now,
+    },
+    endsAt: {
+      type: Date,
+      required: true,
+    },
+    triggeredBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
+    clearedAt: {
+      type: Date,
+      default: null,
+    },
+    clearedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
+    clearReason: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    metadata: {
+      type: mongoose.Schema.Types.Mixed,
+      default: {},
+    },
+  },
+  { _id: true },
+);
 
 const userSchema = new mongoose.Schema(
   {
@@ -40,23 +121,7 @@ const userSchema = new mongoose.Schema(
       default: "",
     },
     campusScopes: {
-      type: [
-        new mongoose.Schema(
-          {
-            campusId: {
-              type: String,
-              trim: true,
-              default: "",
-            },
-            campusName: {
-              type: String,
-              trim: true,
-              default: "",
-            },
-          },
-          { _id: false },
-        ),
-      ],
+      type: [campusScopeSchema],
       default: [],
     },
     role: {
@@ -90,6 +155,10 @@ const userSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
       default: null,
+    },
+    cooldowns: {
+      type: [cooldownSchema],
+      default: [],
     },
   },
   {
@@ -139,4 +208,4 @@ userSchema.methods.generateRefreshToken = function generateRefreshToken() {
 
 const User = mongoose.model("User", userSchema);
 
-export { User, allowedRoles };
+export { User, allowedCooldownActions, allowedCooldownSourceTypes, allowedRoles };

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -2,12 +2,15 @@ import { Router } from "express";
 
 import {
   archiveTask,
+  clearUserCooldown,
+  createUserCooldown,
   getUserCampusScopes,
   listFraudFlags,
   getRunnerPerformanceById,
   getRunnerPerformanceMetrics,
   getAdminAnalyticsDashboard,
   listReportedIssues,
+  listUserCooldowns,
   suspendUser,
   updateFraudFlagStatus,
   updateReportStatus,
@@ -25,6 +28,17 @@ router.put(
   "/users/:userId/campus-scopes",
   createIdempotencyMiddleware(),
   updateUserCampusScopes,
+);
+router.get("/users/:userId/cooldowns", listUserCooldowns);
+router.post(
+  "/users/:userId/cooldowns",
+  createIdempotencyMiddleware(),
+  createUserCooldown,
+);
+router.patch(
+  "/users/:userId/cooldowns/:cooldownId/clear",
+  createIdempotencyMiddleware(),
+  clearUserCooldown,
 );
 router.get("/runners/performance", getRunnerPerformanceMetrics);
 router.get("/runners/:runnerId/performance", getRunnerPerformanceById);

--- a/backend/src/routes/task.routes.js
+++ b/backend/src/routes/task.routes.js
@@ -13,6 +13,7 @@ import {
   markTaskInProgress,
 } from "../controllers/task.controller.js";
 import { authorizeRoles, verifyJWT } from "../middlewares/auth.middleware.js";
+import { createCooldownMiddleware } from "../middlewares/cooldown.middleware.js";
 import { createIdempotencyMiddleware } from "../middlewares/idempotency.middleware.js";
 
 const router = Router();
@@ -27,12 +28,14 @@ router.get("/:taskId", getTaskById);
 router.post(
   "/",
   authorizeRoles("requester", "admin"),
+  createCooldownMiddleware({ action: "task_creation" }),
   createIdempotencyMiddleware(),
   createTask,
 );
 router.patch(
   "/:taskId/accept",
   authorizeRoles("runner", "admin"),
+  createCooldownMiddleware({ action: "task_acceptance" }),
   createIdempotencyMiddleware(),
   acceptTask,
 );
@@ -51,6 +54,7 @@ router.patch(
 router.patch(
   "/:taskId/cancel",
   authorizeRoles("requester", "admin"),
+  createCooldownMiddleware({ action: "task_cancellation" }),
   createIdempotencyMiddleware(),
   cancelTask,
 );

--- a/backend/src/routes/wallet.routes.js
+++ b/backend/src/routes/wallet.routes.js
@@ -11,6 +11,7 @@ import {
   updateWalletTransactionStatus,
 } from "../controllers/wallet.controller.js";
 import { authorizeRoles, verifyJWT } from "../middlewares/auth.middleware.js";
+import { createCooldownMiddleware } from "../middlewares/cooldown.middleware.js";
 import { createIdempotencyMiddleware } from "../middlewares/idempotency.middleware.js";
 
 const router = Router();
@@ -22,6 +23,7 @@ router.get("/transactions", listWalletTransactions);
 router.post(
   "/withdrawals",
   authorizeRoles("runner"),
+  createCooldownMiddleware({ action: "wallet_withdrawal", bypassRoles: [] }),
   createIdempotencyMiddleware(),
   createWithdrawalRequest,
 );

--- a/backend/src/services/cooldown.service.js
+++ b/backend/src/services/cooldown.service.js
@@ -1,0 +1,165 @@
+import { User, allowedCooldownActions } from "../models/user.model.js";
+
+const cooldownActionLabels = {
+  task_creation: "Task creation",
+  task_cancellation: "Task cancellation",
+  task_acceptance: "Task acceptance",
+  wallet_withdrawal: "Wallet withdrawals",
+};
+
+const cooldownPolicies = {
+  repeated_cancellations: {
+    medium: {
+      durationHours: 12,
+      targets: (flag) => [
+        { userId: flag.user, action: "task_creation" },
+        { userId: flag.user, action: "task_cancellation" },
+      ],
+    },
+    high: {
+      durationHours: 24,
+      targets: (flag) => [
+        { userId: flag.user, action: "task_creation" },
+        { userId: flag.user, action: "task_cancellation" },
+      ],
+    },
+  },
+  wallet_abuse: {
+    medium: {
+      durationHours: 24,
+      targets: (flag) => [{ userId: flag.user, action: "wallet_withdrawal" }],
+    },
+    high: {
+      durationHours: 48,
+      targets: (flag) => [{ userId: flag.user, action: "wallet_withdrawal" }],
+    },
+  },
+  unusually_fast_completion: {
+    medium: {
+      durationHours: 6,
+      targets: (flag) => [{ userId: flag.user, action: "task_acceptance" }],
+    },
+    high: {
+      durationHours: 12,
+      targets: (flag) => [{ userId: flag.user, action: "task_acceptance" }],
+    },
+  },
+  self_dealing_pattern: {
+    medium: {
+      durationHours: 12,
+      targets: (flag) => [{ userId: flag.secondaryUser, action: "task_acceptance" }],
+    },
+    high: {
+      durationHours: 24,
+      targets: (flag) => [{ userId: flag.secondaryUser, action: "task_acceptance" }],
+    },
+  },
+};
+
+const isCooldownActive = (cooldown, now = new Date()) => {
+  return Boolean(cooldown && !cooldown.clearedAt && cooldown.endsAt > now);
+};
+
+const getActiveCooldownForAction = (user, action, now = new Date()) => {
+  const matchingCooldowns = (user?.cooldowns || []).filter(
+    (cooldown) => cooldown.action === action && isCooldownActive(cooldown, now),
+  );
+
+  if (matchingCooldowns.length === 0) {
+    return null;
+  }
+
+  return matchingCooldowns.sort((left, right) => right.endsAt - left.endsAt)[0];
+};
+
+const getCooldownActionLabel = (action) => {
+  return cooldownActionLabels[action] || "This action";
+};
+
+const applyUserCooldown = async ({
+  userId,
+  action,
+  durationHours,
+  reason,
+  sourceType,
+  triggeredBy = null,
+  metadata = {},
+}) => {
+  if (!userId || !allowedCooldownActions.includes(action) || durationHours <= 0) {
+    return null;
+  }
+
+  const user = await User.findById(userId);
+  if (!user) {
+    return null;
+  }
+
+  const now = new Date();
+  const endsAt = new Date(now.getTime() + durationHours * 60 * 60 * 1000);
+
+  let cooldown = user.cooldowns.find(
+    (entry) => entry.action === action && !entry.clearedAt && entry.endsAt > now,
+  );
+
+  if (!cooldown) {
+    user.cooldowns.push({
+      action,
+      reason,
+      sourceType,
+      startsAt: now,
+      endsAt,
+      triggeredBy,
+      metadata,
+    });
+    cooldown = user.cooldowns[user.cooldowns.length - 1];
+  } else {
+    cooldown.reason = reason;
+    cooldown.sourceType = sourceType;
+    cooldown.triggeredBy = triggeredBy || cooldown.triggeredBy;
+    cooldown.metadata = metadata;
+
+    if (endsAt > cooldown.endsAt) {
+      cooldown.endsAt = endsAt;
+    }
+  }
+
+  await user.save({ validateBeforeSave: false });
+
+  return cooldown;
+};
+
+const syncAutomaticCooldownsForFraudFlag = async (flag) => {
+  const policyBySeverity = cooldownPolicies[flag?.flagType];
+  const policy = policyBySeverity?.[flag?.severity];
+
+  if (!policy) {
+    return [];
+  }
+
+  const targets = policy.targets(flag).filter((target) => target.userId && target.action);
+  const reason = `${flag.title} Automatic cooldown applied while suspicious activity is reviewed.`;
+
+  return Promise.all(
+    targets.map((target) =>
+      applyUserCooldown({
+        userId: target.userId,
+        action: target.action,
+        durationHours: policy.durationHours,
+        reason,
+        sourceType: flag.flagType,
+        metadata: {
+          fraudFlagId: String(flag._id),
+          severity: flag.severity,
+        },
+      }),
+    ),
+  );
+};
+
+export {
+  applyUserCooldown,
+  getActiveCooldownForAction,
+  getCooldownActionLabel,
+  isCooldownActive,
+  syncAutomaticCooldownsForFraudFlag,
+};

--- a/backend/src/services/fraudDetection.service.js
+++ b/backend/src/services/fraudDetection.service.js
@@ -1,6 +1,7 @@
 import { FraudFlag } from "../models/fraudFlag.model.js";
 import { Task } from "../models/task.model.js";
 import { WalletTransaction } from "../models/walletTransaction.model.js";
+import { syncAutomaticCooldownsForFraudFlag } from "./cooldown.service.js";
 
 const unresolvedFraudFlagStatuses = ["open", "reviewed"];
 
@@ -34,10 +35,11 @@ const recordFraudFlag = async ({
     existingFlag.occurrenceCount += 1;
 
     await existingFlag.save();
+    await syncAutomaticCooldownsForFraudFlag(existingFlag);
     return existingFlag;
   }
 
-  return FraudFlag.create({
+  const createdFlag = await FraudFlag.create({
     fingerprint,
     flagType,
     severity,
@@ -50,6 +52,10 @@ const recordFraudFlag = async ({
     walletTransaction,
     lastDetectedAt: new Date(),
   });
+
+  await syncAutomaticCooldownsForFraudFlag(createdFlag);
+
+  return createdFlag;
 };
 
 const detectRepeatedCancellation = async (task) => {

--- a/backend/test/cooldown-enforcement.test.js
+++ b/backend/test/cooldown-enforcement.test.js
@@ -1,0 +1,261 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+process.env.ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET || "test-access-secret";
+process.env.REFRESH_TOKEN_SECRET =
+  process.env.REFRESH_TOKEN_SECRET || "test-refresh-secret";
+process.env.CORS_ORIGIN = process.env.CORS_ORIGIN || "http://localhost:3000";
+process.env.MONGODB_URI = process.env.MONGODB_URI || "mongodb://127.0.0.1:27017";
+
+const [{ app }, { Task }, { User }, { WalletTransaction }, { FraudFlag }] = await Promise.all([
+  import("../src/app.js"),
+  import("../src/models/task.model.js"),
+  import("../src/models/user.model.js"),
+  import("../src/models/walletTransaction.model.js"),
+  import("../src/models/fraudFlag.model.js"),
+]);
+
+const createAccessToken = (user) =>
+  jwt.sign(
+    {
+      _id: user._id.toString(),
+      email: user.email,
+      role: user.role,
+    },
+    process.env.ACCESS_TOKEN_SECRET,
+    {
+      expiresIn: "1h",
+    },
+  );
+
+const createUser = async ({ fullName, email, role }) => {
+  return User.create({
+    fullName,
+    email,
+    password: "Password123!",
+    role,
+    isVerified: true,
+    isActive: true,
+    phoneNumber: "",
+    campusId: "main-campus",
+    campusName: "Main Campus",
+    campusScopes: [
+      {
+        campusId: "main-campus",
+        campusName: "Main Campus",
+      },
+    ],
+  });
+};
+
+const createTaskForRequester = async (authHeader, title) => {
+  const response = await request(app)
+    .post("/api/v1/tasks")
+    .set(authHeader)
+    .send({
+      title,
+      description: `${title} description`,
+      pickupLocation: "Academic Block",
+      dropoffLocation: "Library",
+      campus: "Main Campus",
+      reward: 50,
+    });
+
+  assert.equal(response.status, 201);
+  return response.body.data.id;
+};
+
+describe("cooldown enforcement", () => {
+  let mongoServer;
+
+  before(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri(), {
+      dbName: "campus-runner-cooldown-tests",
+    });
+  });
+
+  after(async () => {
+    await mongoose.disconnect();
+
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      User.deleteMany({}),
+      Task.deleteMany({}),
+      WalletTransaction.deleteMany({}),
+      FraudFlag.deleteMany({}),
+    ]);
+  });
+
+  it("blocks requester task creation after repeated cancellations and lets an admin clear the cooldown", async () => {
+    const [admin, requester] = await Promise.all([
+      createUser({ fullName: "Admin Cooldown", email: "admin-cooldown@example.com", role: "admin" }),
+      createUser({
+        fullName: "Requester Cooldown",
+        email: "requester-cooldown@example.com",
+        role: "requester",
+      }),
+    ]);
+
+    const adminAuth = { Authorization: `Bearer ${createAccessToken(admin)}` };
+    const requesterAuth = { Authorization: `Bearer ${createAccessToken(requester)}` };
+
+    for (let index = 0; index < 3; index += 1) {
+      const taskId = await createTaskForRequester(requesterAuth, `Cancelled task ${index}`);
+      const cancelResponse = await request(app)
+        .patch(`/api/v1/tasks/${taskId}/cancel`)
+        .set(requesterAuth)
+        .send({ cancellationReason: `Cancellation ${index}` });
+
+      assert.equal(cancelResponse.status, 200);
+    }
+
+    const blockedCreateResponse = await request(app)
+      .post("/api/v1/tasks")
+      .set(requesterAuth)
+      .send({
+        title: "Blocked task",
+        description: "Blocked task description",
+        pickupLocation: "Academic Block",
+        dropoffLocation: "Library",
+        campus: "Main Campus",
+        reward: 40,
+      });
+
+    assert.equal(blockedCreateResponse.status, 429);
+    assert.match(blockedCreateResponse.body.message, /cooldown/i);
+
+    const cooldownListResponse = await request(app)
+      .get(`/api/v1/admin/users/${requester._id}/cooldowns`)
+      .set(adminAuth);
+
+    assert.equal(cooldownListResponse.status, 200);
+    assert.equal(cooldownListResponse.body.data.activeCooldowns.length, 2);
+
+    const taskCreationCooldown = cooldownListResponse.body.data.activeCooldowns.find(
+      (cooldown) => cooldown.action === "task_creation",
+    );
+
+    assert.ok(taskCreationCooldown);
+
+    const clearCooldownResponse = await request(app)
+      .patch(`/api/v1/admin/users/${requester._id}/cooldowns/${taskCreationCooldown.id}/clear`)
+      .set(adminAuth)
+      .send({ clearReason: "Requester verified by admin" });
+
+    assert.equal(clearCooldownResponse.status, 200);
+    assert.equal(clearCooldownResponse.body.data.cooldown.clearReason, "Requester verified by admin");
+    assert.equal(clearCooldownResponse.body.data.cooldown.isActive, false);
+
+    const allowedCreateResponse = await request(app)
+      .post("/api/v1/tasks")
+      .set(requesterAuth)
+      .send({
+        title: "Allowed task",
+        description: "Allowed task description",
+        pickupLocation: "Academic Block",
+        dropoffLocation: "Library",
+        campus: "Main Campus",
+        reward: 60,
+      });
+
+    assert.equal(allowedCreateResponse.status, 201);
+  });
+
+  it("blocks runner withdrawals after repeated failed payout reviews", async () => {
+    const [admin, runner] = await Promise.all([
+      createUser({ fullName: "Admin Wallet", email: "admin-wallet@example.com", role: "admin" }),
+      createUser({ fullName: "Runner Wallet", email: "runner-wallet@example.com", role: "runner" }),
+    ]);
+
+    await WalletTransaction.create({
+      user: runner._id,
+      type: "credit",
+      amount: 300,
+      status: "completed",
+      category: "manual",
+      description: "Runner earnings credit",
+      reference: "EARN-WALLET-001",
+      initiatedBy: admin._id,
+    });
+
+    const adminAuth = { Authorization: `Bearer ${createAccessToken(admin)}` };
+    const runnerAuth = { Authorization: `Bearer ${createAccessToken(runner)}` };
+
+    for (let index = 0; index < 3; index += 1) {
+      const withdrawalResponse = await request(app)
+        .post("/api/v1/wallet/withdrawals")
+        .set(runnerAuth)
+        .send({ amount: 20, reference: `WD-FAIL-${index}` });
+
+      assert.equal(withdrawalResponse.status, 201);
+
+      const rejectResponse = await request(app)
+        .patch(`/api/v1/wallet/withdrawals/${withdrawalResponse.body.data.id}/reject`)
+        .set(adminAuth)
+        .send({
+          failureReason: `Bank reject ${index}`,
+          reviewNote: "Retry later",
+        });
+
+      assert.equal(rejectResponse.status, 200);
+      assert.equal(rejectResponse.body.data.status, "failed");
+    }
+
+    const blockedWithdrawalResponse = await request(app)
+      .post("/api/v1/wallet/withdrawals")
+      .set(runnerAuth)
+      .send({ amount: 10, reference: "WD-BLOCKED" });
+
+    assert.equal(blockedWithdrawalResponse.status, 429);
+    assert.match(blockedWithdrawalResponse.body.message, /cooldown/i);
+  });
+
+  it("blocks runner task acceptance after suspicious fast completions", async () => {
+    const [requester, runner] = await Promise.all([
+      createUser({ fullName: "Requester Fraud", email: "requester-fraud@example.com", role: "requester" }),
+      createUser({ fullName: "Runner Fraud", email: "runner-fraud@example.com", role: "runner" }),
+    ]);
+
+    const requesterAuth = { Authorization: `Bearer ${createAccessToken(requester)}` };
+    const runnerAuth = { Authorization: `Bearer ${createAccessToken(runner)}` };
+
+    for (let index = 0; index < 3; index += 1) {
+      const taskId = await createTaskForRequester(requesterAuth, `Fast completion ${index}`);
+
+      const acceptResponse = await request(app)
+        .patch(`/api/v1/tasks/${taskId}/accept`)
+        .set(runnerAuth);
+      assert.equal(acceptResponse.status, 200);
+
+      const inProgressResponse = await request(app)
+        .patch(`/api/v1/tasks/${taskId}/in-progress`)
+        .set(runnerAuth);
+      assert.equal(inProgressResponse.status, 200);
+
+      const completeResponse = await request(app)
+        .patch(`/api/v1/tasks/${taskId}/complete`)
+        .set(runnerAuth);
+      assert.equal(completeResponse.status, 200);
+    }
+
+    const nextTaskId = await createTaskForRequester(requesterAuth, "Blocked acceptance task");
+    const blockedAcceptResponse = await request(app)
+      .patch(`/api/v1/tasks/${nextTaskId}/accept`)
+      .set(runnerAuth);
+
+    assert.equal(blockedAcceptResponse.status, 429);
+    assert.match(blockedAcceptResponse.body.message, /cooldown/i);
+  });
+});


### PR DESCRIPTION
#129 solved 

This PR adds backend-only cooldown enforcement to automatically restrict risky account actions after repeated abuse signals and give admins direct recovery controls: users now carry structured cooldown state, fraud detection automatically applies timed cooldowns after repeated task cancellations, repeated failed wallet debits, and suspicious fast-completion/self-dealing patterns, protected task creation/task cancellation/task acceptance and wallet withdrawal routes now return a temporary block with retry metadata when a cooldown is active, and new admin endpoints let moderators view a user’s cooldown history, apply a manual cooldown, and clear an active cooldown when needed; focused backend tests were also added to cover automatic triggering, enforcement, and admin override flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cooldown enforcement for key actions (task creation, acceptance, withdrawals) with Retry-After guidance and role-aware bypass.
  * Admins can list, create, and clear user cooldowns via management endpoints (idempotent where applicable).
  * Automatic cooldowns applied from fraud-detection policies with human-friendly action labels.

* **Tests**
  * End-to-end tests covering cooldown triggering, enforcement, admin management, and clearing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->