### PR TITLE
feat(health): add optional runtime metadata endpoint details

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -38,11 +38,27 @@ app.get("/api-docs.json", (_, res) => {
 
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument))
 
-app.get("/api/v1/health", (_, res) => {
-    res.status(200).json({
+app.get("/api/v1/health", (req, res) => {
+    const includeMeta = ["true", "1", "yes"].includes(
+        String(req.query?.includeMeta || "").toLowerCase()
+    );
+
+    const response = {
         success: true,
         message: "Backend is healthy",
-    });
+    };
+
+    if (includeMeta) {
+        response.meta = {
+            service: "campus-runner-backend",
+            environment: process.env.NODE_ENV || "development",
+            timestamp: new Date().toISOString(),
+            uptimeSeconds: Math.floor(process.uptime()),
+            version: process.env.npm_package_version || null,
+        };
+    }
+
+    res.status(200).json(response);
 })
 
 app.use("/api/v1/auth", authRouter)

--- a/backend/src/docs/swagger.js
+++ b/backend/src/docs/swagger.js
@@ -1058,9 +1058,42 @@ const swaggerDocument = {
       get: {
         tags: ["Health"],
         summary: "Health check",
+        parameters: [
+          {
+            in: "query",
+            name: "includeMeta",
+            schema: { type: "boolean" },
+            required: false,
+            description: "Include runtime metadata like uptime, environment, timestamp, and version.",
+          },
+        ],
         responses: {
           200: {
             description: "Backend is healthy",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    message: { type: "string", example: "Backend is healthy" },
+                    meta: {
+                      type: "object",
+                      nullable: true,
+                      properties: {
+                        service: { type: "string", example: "campus-runner-backend" },
+                        environment: { type: "string", example: "production" },
+                        timestamp: { type: "string", format: "date-time" },
+                        uptimeSeconds: { type: "integer", example: 1250 },
+                        version: {
+                          anyOf: [{ type: "string", example: "1.0.0" }, { type: "null" }],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
           },
         },
       },

--- a/backend/test/health-endpoint.test.js
+++ b/backend/test/health-endpoint.test.js
@@ -1,0 +1,40 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+process.env.ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET || "test-access-secret";
+process.env.REFRESH_TOKEN_SECRET =
+  process.env.REFRESH_TOKEN_SECRET || "test-refresh-secret";
+process.env.CORS_ORIGIN = process.env.CORS_ORIGIN || "http://localhost:3000";
+
+const { app } = await import("../src/app.js");
+
+describe("health endpoint", () => {
+  it("returns the existing stable payload by default", async () => {
+    const response = await request(app).get("/api/v1/health");
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.body, {
+      success: true,
+      message: "Backend is healthy",
+    });
+  });
+
+  it("returns runtime metadata when includeMeta=true", async () => {
+    const response = await request(app).get("/api/v1/health?includeMeta=true");
+
+    assert.equal(response.status, 200);
+    assert.equal(response.body.success, true);
+    assert.equal(response.body.message, "Backend is healthy");
+    assert.equal(response.body.meta.service, "campus-runner-backend");
+    assert.equal(response.body.meta.environment, "test");
+    assert.ok(Number.isInteger(response.body.meta.uptimeSeconds));
+    assert.ok(response.body.meta.uptimeSeconds >= 0);
+    assert.ok(!Number.isNaN(Date.parse(response.body.meta.timestamp)));
+    assert.ok(
+      response.body.meta.version === null || typeof response.body.meta.version === "string",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep existing  response backward-compatible by default
- add optional metadata via  query parameter (service, environment, timestamp, uptime, version)
- document the new query parameter and response shape in Swagger
- add backend test coverage for default and metadata responses

## Notes
- no existing behavior is changed unless metadata is explicitly requested
- tests were added but not executed in this environment because dependency installation was interrupted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Health check endpoint now accepts an optional `includeMeta` query parameter to include additional runtime metadata (environment, uptime, timestamp, and version) in the response.

* **Documentation**
  * Updated API documentation for the health endpoint with new parameter and response schema details.

* **Tests**
  * Added test coverage for the health endpoint functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->